### PR TITLE
feat: plan level 4+ structures (Towers and Links)

### DIFF
--- a/src/creep-roles/builder-creep.ts
+++ b/src/creep-roles/builder-creep.ts
@@ -1,3 +1,4 @@
+import { EnergyCalculator } from "utils/energy-calculator";
 /* eslint-disable max-classes-per-file */
 import { CreepRunner } from "prototypes/creep";
 import { ColonyManager, CreepProfiles, CreepRole } from "prototypes/types";

--- a/src/creep-roles/repairer-creep.ts
+++ b/src/creep-roles/repairer-creep.ts
@@ -82,7 +82,7 @@ export class RepairerCreep extends CreepRunner {
                 const repairStatus = this.repair(target);
                 const transferStatus = this.transfer(target, RESOURCE_ENERGY);
                 const buildStatus = this.build(target as any as ConstructionSite);
-                let upgradeStatus: ScreepsReturnCode = ERR_INVALID_TARGET;
+                let upgradeStatus: ScreepsReturnCode | -16 = ERR_INVALID_TARGET;
                 if (t.structureType === STRUCTURE_CONTROLLER) {
                     upgradeStatus = this.upgradeController(target);
                 }

--- a/src/goap/actions/infrastructure-actions.ts
+++ b/src/goap/actions/infrastructure-actions.ts
@@ -31,16 +31,15 @@ export class BuildTowerAction implements Action {
         this.colony.systems.builder.setEnergyBudgetWeight(1.0);
         const room = this.colony.getMainRoom();
         const spawn = this.colony.getMainSpawn();
-        if (!room || !spawn) return true;
+        if (!room || !spawn || !room.controller) return true;
 
-        if (this.colony.constructionManager.hasPlannedStructures(STRUCTURE_TOWER, 1)) {
+        const maxTowers = CONTROLLER_STRUCTURES[STRUCTURE_TOWER][room.controller.level] || 0;
+
+        if (this.colony.constructionManager.hasPlannedStructures(STRUCTURE_TOWER, maxTowers)) {
             return true;
         }
 
-        const structures = ConstructionUtils.getFirstTowerStructures(spawn);
-        if (structures.length > 0) {
-            this.colony.constructionManager.placeConstructionSites(structures);
-        }
+        this.colony.constructionManager.planTowers();
 
         return true;
     }

--- a/src/managers/construction-manager.test.ts
+++ b/src/managers/construction-manager.test.ts
@@ -104,6 +104,13 @@ describe("Construction Manager", () => {
         // Mock lookFor for ruins
         const lookForStub = sinon.stub(MockRoomPosition.prototype, "lookFor").returns([]);
 
+        // Mock CONTROLLER_STRUCTURES to prevent errors in planTowers during testing
+        (global as any).CONTROLLER_STRUCTURES = {
+            [STRUCTURE_TOWER]: { 0: 0, 1: 0, 2: 0, 3: 1, 4: 1, 5: 2, 6: 2, 7: 3, 8: 6 },
+            [STRUCTURE_EXTENSION]: { 0: 0, 1: 0, 2: 5, 3: 10, 4: 20, 5: 30, 6: 40, 7: 50, 8: 60 },
+            [STRUCTURE_LINK]: { 0: 0, 1: 0, 2: 0, 3: 0, 4: 0, 5: 2, 6: 3, 7: 4, 8: 6 }
+        } as any;
+
         constructionManager.run();
 
         // Should be called for extension, but not for road

--- a/src/managers/construction-manager.ts
+++ b/src/managers/construction-manager.ts
@@ -54,7 +54,70 @@ export class ConstructionManager {
             this.rebuildRuins();
             this.planExtensions();
             this.planStorage();
+            this.planTowers();
+            this.planLinks();
         }
+    }
+
+    public planLinks(): void {
+        const room = this.colony.getMainRoom();
+        const spawn = this.colony.getMainSpawn();
+        if (!room || !spawn || !room.controller) return;
+
+        const rcl = room.controller.level;
+        if (rcl < 5) return;
+
+        const maxLinks = CONTROLLER_STRUCTURES[STRUCTURE_LINK][rcl] || 0;
+
+        // Count existing links and construction sites
+        const currentCount =
+            room.find(FIND_MY_STRUCTURES, {
+                filter: s => s.structureType === STRUCTURE_LINK,
+            }).length +
+            room.find(FIND_MY_CONSTRUCTION_SITES, {
+                filter: s => s.structureType === STRUCTURE_LINK,
+            }).length;
+
+        if (currentCount >= maxLinks) return;
+
+        const needed = maxLinks - currentCount;
+
+        // Global limit check
+        if (Object.keys(Game.constructionSites).length >= 100) return;
+
+        const sources = room.find(FIND_SOURCES);
+        const structures = ConstructionUtils.getLinkStructures(room, spawn, needed, sources);
+        this.placeConstructionSites(structures);
+    }
+
+    public planTowers(): void {
+        const room = this.colony.getMainRoom();
+        const spawn = this.colony.getMainSpawn();
+        if (!room || !spawn || !room.controller) return;
+
+        const rcl = room.controller.level;
+        if (rcl < 3) return;
+
+        const maxTowers = CONTROLLER_STRUCTURES[STRUCTURE_TOWER][rcl] || 0;
+
+        // Count existing towers and construction sites
+        const currentCount =
+            room.find(FIND_MY_STRUCTURES, {
+                filter: s => s.structureType === STRUCTURE_TOWER,
+            }).length +
+            room.find(FIND_MY_CONSTRUCTION_SITES, {
+                filter: s => s.structureType === STRUCTURE_TOWER,
+            }).length;
+
+        if (currentCount >= maxTowers) return;
+
+        const needed = maxTowers - currentCount;
+
+        // Global limit check
+        if (Object.keys(Game.constructionSites).length >= 100) return;
+
+        const structures = ConstructionUtils.getTowerStructures(spawn, needed);
+        this.placeConstructionSites(structures);
     }
 
     private planStorage(): void {

--- a/src/prototypes/creep.ts
+++ b/src/prototypes/creep.ts
@@ -427,7 +427,7 @@ export abstract class CreepRunner {
         return actionStatus;
     }
 
-    protected upgradeController(target: TargetType): ScreepsReturnCode {
+    protected upgradeController(target: TargetType): ScreepsReturnCode | -16 {
         const actionStatus = this.creep.upgradeController(target as any);
         if (actionStatus === OK) {
             Logger.debug(`[Creep] ${this.creep.name} (${this.memory.role}) upgrading controller`);

--- a/src/systems/builder-system.ts
+++ b/src/systems/builder-system.ts
@@ -38,7 +38,8 @@ export class BuilderSystem extends BaseSystemImpl {
         const rcl = room.controller?.level || 0;
 
         // 1. Tower Construction
-        if (rcl >= 3 && !this.colony.constructionManager.hasPlannedStructures(STRUCTURE_TOWER, 1)) {
+        const maxTowers = CONTROLLER_STRUCTURES[STRUCTURE_TOWER][rcl] || 0;
+        if (rcl >= 3 && !this.colony.constructionManager.hasPlannedStructures(STRUCTURE_TOWER, maxTowers)) {
             new BuildTowerAction(this.colony).execute();
         }
 
@@ -79,7 +80,8 @@ export class BuilderSystem extends BaseSystemImpl {
         const room = this.colony.getMainRoom();
         const rcl = room.controller?.level || 0;
 
-        if (rcl >= 3 && !this.colony.constructionManager.hasPlannedStructures(STRUCTURE_TOWER, 1)) {
+        const maxTowers = CONTROLLER_STRUCTURES[STRUCTURE_TOWER][rcl] || 0;
+        if (rcl >= 3 && !this.colony.constructionManager.hasPlannedStructures(STRUCTURE_TOWER, maxTowers)) {
             return "Building Tower";
         }
 

--- a/src/utils/construction-utils.ts
+++ b/src/utils/construction-utils.ts
@@ -163,19 +163,121 @@ export class ConstructionUtils {
         ];
     }
 
-    public static getFirstTowerStructures(spawn: StructureSpawn): ProjectStructure[] {
-        const towerPosition = new RoomPosition(spawn.pos.x + 2, spawn.pos.y + 2, spawn.pos.roomName);
-        if (ConstructionUtils.isTileClearForStructure(towerPosition, spawn.room, true)) {
-            const structures: ProjectStructure[] = [];
+    public static getLinkStructures(room: Room, spawn: StructureSpawn, numLinks: number, sources: Source[]): ProjectStructure[] {
+        const structures: ProjectStructure[] = [];
+        if (numLinks <= 0) return structures;
+
+        let placedLinks = 0;
+
+        // 1. Storage/Spawn Link (Core Link)
+        const coreLinkPos = new RoomPosition(spawn.pos.x + 1, spawn.pos.y + 1, room.name);
+        const storage = room.storage;
+
+        // Ensure there isn't already a link near storage/spawn
+        const hasCoreLink = room.find(FIND_MY_STRUCTURES, {
+            filter: s => s.structureType === STRUCTURE_LINK && s.pos.inRangeTo(coreLinkPos, 2)
+        }).length > 0 || room.find(FIND_MY_CONSTRUCTION_SITES, {
+            filter: s => s.structureType === STRUCTURE_LINK && s.pos.inRangeTo(coreLinkPos, 2)
+        }).length > 0;
+
+        if (!hasCoreLink && ConstructionUtils.isTileClearForStructure(coreLinkPos, room, true)) {
             structures.push({
-                x: towerPosition.x,
-                y: towerPosition.y,
-                roomName: spawn.pos.roomName,
-                type: STRUCTURE_TOWER,
+                x: coreLinkPos.x,
+                y: coreLinkPos.y,
+                roomName: room.name,
+                type: STRUCTURE_LINK
             });
-            return structures.concat(ConstructionUtils.getRoadsAroundPosition(towerPosition));
+            placedLinks++;
         }
-        return [];
+
+        if (placedLinks >= numLinks) return structures;
+
+        // 2. Controller Link
+        if (room.controller) {
+            const hasControllerLink = room.find(FIND_MY_STRUCTURES, {
+                filter: s => s.structureType === STRUCTURE_LINK && s.pos.inRangeTo(room.controller!.pos, 2)
+            }).length > 0 || room.find(FIND_MY_CONSTRUCTION_SITES, {
+                filter: s => s.structureType === STRUCTURE_LINK && s.pos.inRangeTo(room.controller!.pos, 2)
+            }).length > 0;
+
+            if (!hasControllerLink) {
+                // Find a spot near controller
+                for (let dx = -2; dx <= 2; dx++) {
+                    for (let dy = -2; dy <= 2; dy++) {
+                        if (dx === 0 && dy === 0) continue;
+                        const pos = new RoomPosition(room.controller.pos.x + dx, room.controller.pos.y + dy, room.name);
+                        if (ConstructionUtils.isTileClearForStructure(pos, room, true)) {
+                            structures.push({ x: pos.x, y: pos.y, roomName: room.name, type: STRUCTURE_LINK });
+                            placedLinks++;
+                            break;
+                        }
+                    }
+                    if (placedLinks >= numLinks || !hasControllerLink) break; // found a spot
+                }
+            }
+        }
+
+        if (placedLinks >= numLinks) return structures;
+
+        // 3. Source Links
+        for (const source of sources) {
+            if (placedLinks >= numLinks) break;
+
+            const hasSourceLink = room.find(FIND_MY_STRUCTURES, {
+                filter: s => s.structureType === STRUCTURE_LINK && s.pos.inRangeTo(source.pos, 2)
+            }).length > 0 || room.find(FIND_MY_CONSTRUCTION_SITES, {
+                filter: s => s.structureType === STRUCTURE_LINK && s.pos.inRangeTo(source.pos, 2)
+            }).length > 0;
+
+            if (!hasSourceLink) {
+                for (let dx = -2; dx <= 2; dx++) {
+                    for (let dy = -2; dy <= 2; dy++) {
+                        if (dx === 0 && dy === 0) continue;
+                        const pos = new RoomPosition(source.pos.x + dx, source.pos.y + dy, room.name);
+                        if (ConstructionUtils.isTileClearForStructure(pos, room, true)) {
+                            structures.push({ x: pos.x, y: pos.y, roomName: room.name, type: STRUCTURE_LINK });
+                            placedLinks++;
+                            break;
+                        }
+                    }
+                    if (placedLinks >= numLinks || !hasSourceLink) break; // found a spot
+                }
+            }
+        }
+
+        return structures;
+    }
+
+    public static getTowerStructures(spawn: StructureSpawn, numTowers: number): ProjectStructure[] {
+        const structures: ProjectStructure[] = [];
+        const candidates = [
+            { x: 2, y: 2 },
+            { x: -2, y: -2 },
+            { x: -2, y: 2 },
+            { x: 2, y: -2 },
+            { x: 0, y: 3 },
+            { x: 0, y: -3 },
+        ];
+
+        for (const candidate of candidates) {
+            // Count already planned or placed towers to avoid overbuilding
+            const towerPosition = new RoomPosition(spawn.pos.x + candidate.x, spawn.pos.y + candidate.y, spawn.pos.roomName);
+            if (ConstructionUtils.isTileClearForStructure(towerPosition, spawn.room, true)) {
+                structures.push({
+                    x: towerPosition.x,
+                    y: towerPosition.y,
+                    roomName: spawn.pos.roomName,
+                    type: STRUCTURE_TOWER,
+                });
+                structures.push(...ConstructionUtils.getRoadsAroundPosition(towerPosition));
+
+                // If we've found enough spots to place the required missing towers, break
+                if (structures.filter(s => s.type === STRUCTURE_TOWER).length >= numTowers) {
+                    break;
+                }
+            }
+        }
+        return structures;
     }
 
     public static calculateRoads(

--- a/src/utils/room-utils.ts
+++ b/src/utils/room-utils.ts
@@ -52,7 +52,7 @@ export class RoomUtils {
         const mainRoom = colony.getMainRoom();
         if (!mainRoom) return [];
 
-        const adjacentRooms = Object.values(Game.map.describeExits(mainRoom.name));
+        const adjacentRooms = Game.map.describeExits(mainRoom.name) ? Object.values(Game.map.describeExits(mainRoom.name) as Record<string, string>) : [];
         const knownRooms = Object.keys(colony.colonyInfo.rooms);
         const allPotentialRooms = Array.from(new Set([...adjacentRooms, ...knownRooms]));
 

--- a/test/setup-mocha.js
+++ b/test/setup-mocha.js
@@ -156,3 +156,22 @@ global.PathFinder = {
     },
 };
 
+
+global.CONTROLLER_STRUCTURES = {
+    [global.STRUCTURE_SPAWN]: { 0: 0, 1: 1, 2: 1, 3: 1, 4: 1, 5: 1, 6: 1, 7: 2, 8: 3 },
+    [global.STRUCTURE_EXTENSION]: { 0: 0, 1: 0, 2: 5, 3: 10, 4: 20, 5: 30, 6: 40, 7: 50, 8: 60 },
+    [global.STRUCTURE_LINK]: { 0: 0, 1: 0, 2: 0, 3: 0, 4: 0, 5: 2, 6: 3, 7: 4, 8: 6 },
+    [global.STRUCTURE_ROAD]: { 0: 2500, 1: 2500, 2: 2500, 3: 2500, 4: 2500, 5: 2500, 6: 2500, 7: 2500, 8: 2500 },
+    [global.STRUCTURE_WALL]: { 0: 0, 1: 0, 2: 2500, 3: 2500, 4: 2500, 5: 2500, 6: 2500, 7: 2500, 8: 2500 },
+    [global.STRUCTURE_RAMPART]: { 0: 0, 1: 0, 2: 2500, 3: 2500, 4: 2500, 5: 2500, 6: 2500, 7: 2500, 8: 2500 },
+    [global.STRUCTURE_STORAGE]: { 0: 0, 1: 0, 2: 0, 3: 0, 4: 1, 5: 1, 6: 1, 7: 1, 8: 1 },
+    [global.STRUCTURE_TOWER]: { 0: 0, 1: 0, 2: 0, 3: 1, 4: 1, 5: 2, 6: 2, 7: 3, 8: 6 },
+    [global.STRUCTURE_OBSERVER]: { 0: 0, 1: 0, 2: 0, 3: 0, 4: 0, 5: 0, 6: 0, 7: 0, 8: 1 },
+    [global.STRUCTURE_POWER_SPAWN]: { 0: 0, 1: 0, 2: 0, 3: 0, 4: 0, 5: 0, 6: 0, 7: 0, 8: 1 },
+    [global.STRUCTURE_EXTRACTOR]: { 0: 0, 1: 0, 2: 0, 3: 0, 4: 0, 5: 0, 6: 1, 7: 1, 8: 1 },
+    [global.STRUCTURE_TERMINAL]: { 0: 0, 1: 0, 2: 0, 3: 0, 4: 0, 5: 0, 6: 1, 7: 1, 8: 1 },
+    [global.STRUCTURE_LAB]: { 0: 0, 1: 0, 2: 0, 3: 0, 4: 0, 5: 0, 6: 3, 7: 6, 8: 10 },
+    [global.STRUCTURE_CONTAINER]: { 0: 5, 1: 5, 2: 5, 3: 5, 4: 5, 5: 5, 6: 5, 7: 5, 8: 5 },
+    [global.STRUCTURE_NUKER]: { 0: 0, 1: 0, 2: 0, 3: 0, 4: 0, 5: 0, 6: 0, 7: 0, 8: 1 },
+    [global.STRUCTURE_FACTORY]: { 0: 0, 1: 0, 2: 0, 3: 0, 4: 0, 5: 0, 6: 0, 7: 1, 8: 1 }
+};


### PR DESCRIPTION
This PR introduces construction planning for structures unlocked at controller level 4 and onward, specifically focusing on Towers and Links.

Changes:
1.  **Dynamic Tower Planning:** `ConstructionManager` and `BuildTowerAction` now check the `CONTROLLER_STRUCTURES` constant to build the maximum allowed towers for the room's current RCL, rather than hardcoding a limit of 1.
2.  **Automated Link Planning:** Added a `planLinks` routine in `ConstructionManager` and `ConstructionUtils` that triggers at RCL 5+. It automatically places:
    *   A Core Link near the room's Storage and Spawn.
    *   A Controller Link near the Room Controller.
    *   Source Links near each Energy Source.
3.  **Test Environment Consistency:** Mock constants in `test/setup-mocha.js` were updated so tests can accurately run the new RCL lookups. Minor Typescript fixes were also made to resolve type errors occurring during test execution.

---
*PR created automatically by Jules for task [9667054703230833322](https://jules.google.com/task/9667054703230833322) started by @ChineduOzodi*