### PR TITLE
Implement Pre-Emptive Colony Defense

### DIFF
--- a/src/creep-roles/defender-creep.ts
+++ b/src/creep-roles/defender-creep.ts
@@ -16,13 +16,32 @@ export class DefenderCreep extends CreepRunner {
 
     public runDefenderCreep(): void {
         const creep = this.creep;
+        const targetRoomName = creep.memory.homeRoomName;
+
+        // If we are not in our target room, move there
+        if (targetRoomName && creep.room.name !== targetRoomName) {
+            this.moveToWithReservation({ pos: new RoomPosition(25, 25, targetRoomName) }, 0, 20);
+            return;
+        }
+
         const threat = ThreatAssessment.assess(this.creep.room);
 
-        const target = threat.weakestHostile;
+        let target: AnyCreep | Structure | null = threat.weakestHostile;
+
+        if (!target) {
+            target = this.creep.pos.findClosestByRange(FIND_HOSTILE_STRUCTURES, {
+                filter: s => s.structureType !== STRUCTURE_CONTROLLER
+            });
+        }
 
         if (target) {
             if (this.attack(target) === ERR_NOT_IN_RANGE) {
                 this.moveToWithReservation(target, creep.memory.workDuration);
+            }
+        } else {
+            // No targets found in the target room. Reset alert level
+            if (targetRoomName && this.colony && this.colony.colonyInfo.rooms[targetRoomName]) {
+                this.colony.colonyInfo.rooms[targetRoomName].alertLevel = 0;
             }
         }
     }
@@ -34,29 +53,30 @@ export class DefenderCreepSpawner extends CreepSpawnerImpl {
         const profiles: CreepProfiles = {};
         for (const roomName in rooms) {
             const roomInfo = rooms[roomName];
-            const room = Game.rooms[roomInfo.name];
-            if (!room) continue;
 
             const profileName = `${CreepRole.DEFENDER}-${roomInfo.name}`;
-            const hostiles = room.find(FIND_HOSTILE_CREEPS);
-            roomInfo.alertLevel = hostiles.length;
 
             if (roomInfo.alertLevel > 0) {
-                const towers = room.find<StructureTower>(FIND_MY_STRUCTURES, {
-                    filter: { structureType: STRUCTURE_TOWER },
-                });
+                const room = Game.rooms[roomInfo.name];
+                let towersCount = 0;
+                if (room) {
+                    const towers = room.find<StructureTower>(FIND_MY_STRUCTURES, {
+                        filter: { structureType: STRUCTURE_TOWER },
+                    });
+                    towersCount = towers.length;
+                }
 
                 // Determine desired amount based on threat and towers
-                const desiredAmount = Math.max(1, roomInfo.alertLevel - Math.floor(towers.length / 2));
+                const desiredAmount = Math.max(1, roomInfo.alertLevel - Math.floor(towersCount / 2));
 
-                profiles[profileName] = this.createDefenderProfile(roomInfo.name, colony, hostiles);
+                profiles[profileName] = this.createDefenderProfile(roomInfo.name, colony);
                 profiles[profileName].desiredAmount = desiredAmount;
             }
         }
         return profiles;
     }
 
-    private createDefenderProfile(roomName: string, colony: ColonyManager, hostiles: Creep[]): CreepSpawnerProfileInfo {
+    private createDefenderProfile(roomName: string, colony: ColonyManager): CreepSpawnerProfileInfo {
         const room = colony.getMainRoom();
         let energy = room.energyCapacityAvailable;
         if (colony.systems.energy.noEnergyCollectors()) {

--- a/src/creep-roles/healer-creep.ts
+++ b/src/creep-roles/healer-creep.ts
@@ -9,6 +9,8 @@ const BASE_HEALER = [HEAL, MOVE];
 export class HealerCreep extends CreepRunner {
     public override onRun(): void {
         const creep = this.creep;
+        const targetRoomName = creep.memory.homeRoomName;
+
         const target = this.findDefenderToHeal();
 
         if (target) {
@@ -17,6 +19,9 @@ export class HealerCreep extends CreepRunner {
             }
         } else if (creep.hits < creep.hitsMax) {
             creep.heal(creep);
+        } else if (targetRoomName && creep.room.name !== targetRoomName) {
+            // Move to target room if no one to heal here
+            this.moveToWithReservation({ pos: new RoomPosition(25, 25, targetRoomName) }, 0, 20);
         }
     }
 
@@ -34,16 +39,13 @@ export class HealerCreepSpawner extends CreepSpawnerImpl {
         const profiles: CreepProfiles = {};
         for (const roomName in rooms) {
             const roomInfo = rooms[roomName];
-            const room = Game.rooms[roomInfo.name];
-            if (!room) continue;
 
             const profileName = `${CreepRole.HEALER}-${roomInfo.name}`;
             const defendersCount = colony.getCreepCount(CreepRole.DEFENDER);
             const healersCount = colony.getCreepCount(CreepRole.HEALER);
-            const hostiles = room.find(FIND_HOSTILE_CREEPS);
 
             let desiredAmount = 0;
-            if (hostiles.length > 0 && defendersCount >= 2) {
+            if (roomInfo.alertLevel > 0 && defendersCount >= 2) {
                 desiredAmount = Math.floor(defendersCount / 2);
             }
 

--- a/src/creep-roles/scout-creep.ts
+++ b/src/creep-roles/scout-creep.ts
@@ -39,7 +39,9 @@ export class ScoutCreep extends CreepRunner {
             return;
         }
 
-        // We are in the target room. updateRoomVisibility in CreepRunner already handles data update.
+        // We are in the target room. Force an immediate update of the room data to detect threats right away.
+        RoomUtils.updateRoomData(colony, creep.room);
+
         // Scout specific: Sign controller
         const room = creep.room;
         if (room.controller) {

--- a/src/systems/defense-system.ts
+++ b/src/systems/defense-system.ts
@@ -3,6 +3,7 @@ import { CreepRole } from "prototypes/types";
 import { CreepSpawner } from "prototypes/CreepSpawner";
 import { DefenderCreepSpawner } from "creep-roles/defender-creep";
 import { HealerCreepSpawner } from "creep-roles/healer-creep";
+import { RoomUtils } from "utils/room-utils";
 
 export class DefenseSystem extends BaseSystemImpl {
     public override get systemInfo(): BaseSystemInfo {
@@ -34,9 +35,21 @@ export class DefenseSystem extends BaseSystemImpl {
 
     public override run(): void {
         super.run();
-        const room = this.colony.getMainRoom();
-        const hostiles = room.find(FIND_HOSTILE_CREEPS);
-        if (hostiles.length > 0) {
+        let threatLevel = 0;
+        const rooms = this.colony.colonyInfo.rooms;
+        for (const roomName in rooms) {
+            // Actively update room data if we have vision of the room
+            if (Game.rooms[roomName]) {
+                RoomUtils.updateRoomData(this.colony, Game.rooms[roomName]);
+            }
+
+            const roomInfo = rooms[roomName];
+            if (roomInfo.alertLevel > 0) {
+                threatLevel += roomInfo.alertLevel;
+            }
+        }
+
+        if (threatLevel > 0) {
             this.energyUsageTracking.requestedEnergyUsageWeight = 10;
         } else {
             this.energyUsageTracking.requestedEnergyUsageWeight = 0;
@@ -52,8 +65,12 @@ export class DefenseSystem extends BaseSystemImpl {
     }
 
     public override getStatus(): string | null {
-        const room = this.colony.getMainRoom();
-        const hostiles = room.find(FIND_HOSTILE_CREEPS);
-        return hostiles.length > 0 ? "Defending Room" : null;
+        const rooms = this.colony.colonyInfo.rooms;
+        for (const roomName in rooms) {
+            if (rooms[roomName].alertLevel > 0) {
+                return "Defending Colony Area";
+            }
+        }
+        return null;
     }
 }


### PR DESCRIPTION
This PR implements a pre-emptive defense capability for the colony. 

Previously, the colony's defensive response was completely reactionary and only triggered when a hostile creep actively entered the main base. This change allows the AI to proactively assess threats in adjacent/remote rooms (like invader cores or roaming hostile creeps) and dispatch defenders to eliminate them before they become an immediate danger.

**Key Changes:**
- **Threat Detection Pipeline**: The `DefenseSystem` now factors in the `alertLevel` of *all* rooms the colony tracks, not just the main room.
- **Remote Spawning & Deployment**: Both `DefenderCreepSpawner` and `HealerCreepSpawner` now reliably spawn units to deal with threats in rooms without requiring active vision (they utilize the cached `alertLevel`).
- **Scout Precision**: `ScoutCreep` instantly logs threat data via `RoomUtils.updateRoomData` upon entering a room to ensure immediate threat recognition.
- **Offensive Capability**: `DefenderCreep` will route to its assigned remote room and, if no creeps are present, will seek and destroy hostile structures (excluding controllers). Once cleared, it resets the alert level.
- **Support**: `HealerCreep` will follow defenders to the remote room to provide support.

---
*PR created automatically by Jules for task [4620242859225499711](https://jules.google.com/task/4620242859225499711) started by @ChineduOzodi*