### PR TITLE
🧹 Remove deprecated and unused updateProfiles method from BaseSystem

### DIFF
--- a/src/prototypes/colony.ts
+++ b/src/prototypes/colony.ts
@@ -86,10 +86,6 @@ export class ColonyManagerImpl implements ColonyManager {
 
         this.manageEnergyProductionConsumption();
 
-        if (this.shouldUpdate()) {
-            systems.forEach(x => x.updateProfiles());
-        }
-
         spawnManager.run();
         systems.forEach(x => x.run());
         this.constructionManager.run();
@@ -105,14 +101,6 @@ export class ColonyManagerImpl implements ColonyManager {
             systems.push(s[key]);
         }
         return systems;
-    }
-
-    private shouldUpdate(): boolean {
-        if (!this.colonyInfo.nextUpdate || this.colonyInfo.nextUpdate < Game.time) {
-            this.colonyInfo.nextUpdate = Game.time + 10;
-            return true;
-        }
-        return false;
     }
 
     public visualizeStats(): void {

--- a/src/prototypes/types.ts
+++ b/src/prototypes/types.ts
@@ -62,9 +62,6 @@ export interface BaseSystem {
 
     run(): void;
 
-    /** Functionality to update profiles of creeps to be spawned by the spawning system. Primarily invoked by colony manager. */
-    updateProfiles(): void;
-
     /** Get Roles to track energy */
     getRolesToTrackEnergy(): CreepRole[];
 

--- a/src/systems/base-system.ts
+++ b/src/systems/base-system.ts
@@ -31,10 +31,6 @@ export abstract class BaseSystemImpl implements BaseSystem {
         return scaledBody;
     }
 
-    public updateProfiles(): void {
-        // Deprecated: Profiles are now generated dynamically in getSpawnerProfilesList
-    }
-
     public getSpawnerProfilesList(): CreepSpawnerProfileInfo[] {
         const creepSpawners = this.getCreepSpawners();
         const profiles: CreepSpawnerProfileInfo[] = [];


### PR DESCRIPTION
🎯 **What:** The code health issue addressed is the presence of an unnecessary, empty, and deprecated method `updateProfiles()` in `src/systems/base-system.ts`, along with its associated calls and interface definitions.

💡 **Why:** Removing dead and deprecated code improves the maintainability and readability of the codebase by eliminating confusion and simplifying the logical flow. `updateProfiles` functionality was already moved entirely to `getSpawnerProfilesList`.

✅ **Verification:**
- Validated that the `updateProfiles` method was indeed empty and documented as deprecated.
- Removed the method from `BaseSystemImpl` and its interface definition in `BaseSystem`.
- Found and removed its callsite in `src/prototypes/colony.ts` inside a conditional block.
- Confirmed the conditional helper `shouldUpdate()` was used only for this deprecated call and removed it as well.
- Re-ran the full test suite which passed successfully (81 passing).
- Verified build succeeded successfully.
- Code review returned a #Correct# rating.

✨ **Result:** A cleaner codebase with less dead code and simpler colony update loop.

---
*PR created automatically by Jules for task [7309243976643960450](https://jules.google.com/task/7309243976643960450) started by @ChineduOzodi*