### PR TITLE
🧹 Strongly type targetId in CreepMemory to Id<_HasId>

### DIFF
--- a/src/infrastructure/movement.ts
+++ b/src/infrastructure/movement.ts
@@ -170,7 +170,7 @@ export class Movement {
 
     public static moveToTargetByPath(
         creep: Creep,
-        targetId: string | undefined,
+        targetId: Id<_HasId> | undefined,
         targetPos: RoomPosition | undefined,
         targetRange: number,
         path: RoomPosition[],
@@ -188,7 +188,7 @@ export class Movement {
 
     public static moveToTargetByPathWithReservation(
         creep: Creep,
-        targetId: string | undefined,
+        targetId: Id<_HasId> | undefined,
         targetPos: RoomPosition | undefined,
         targetRange: number,
         path: RoomPosition[],

--- a/src/prototypes/creep.extensions.ts
+++ b/src/prototypes/creep.extensions.ts
@@ -5,7 +5,7 @@ declare global {
         name: string;
         colonyId: string;
         movementSystem?: CreepMovementSystem;
-        targetId?: string; // TODO: convert to Id<Tombstone | StructureExtension | AnyStructure | Resource<ResourceConstant> | Source | ConstructionSite<BuildableStructureConstant> or _HasId
+        targetId?: Id<_HasId>;
         targetPos?: RoomPosition;
         working: boolean;
         workDuration: number;


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was a TODO to correctly type `targetId` in `CreepMemory`.
💡 **Why:** `targetId` was loosely typed as `string`, which bypasses type checking for valid Screeps object IDs. The type has been tightened to `Id<_HasId>` to ensure safety.
✅ **Verification:** Replaced `targetId: string | undefined` with `Id<_HasId> | undefined` in `src/infrastructure/movement.ts` and confirmed `tsc` typechecks fully. Tests pass seamlessly.
✨ **Result:** A safer, strongly-typed environment reducing potential runtime bugs around invalid IDs.

---
*PR created automatically by Jules for task [12074112776783275248](https://jules.google.com/task/12074112776783275248) started by @ChineduOzodi*