### PR TITLE
🧹 refactor: remove commented-out dead code in profiler

### DIFF
--- a/src/utils/profiler/profiler.ts
+++ b/src/utils/profiler/profiler.ts
@@ -219,15 +219,3 @@ function outputProfilerData() {
     console.log(output);
 }
 
-// debugging
-// function printObject(obj: object) {
-//   const name = obj.constructor ? obj.constructor.name : (obj as any).name;
-//   console.log("  Keys of :", name, ":");
-//   Reflect.ownKeys(obj).forEach((k) => {
-//     try {
-//       console.log(`    ${k}: ${Reflect.get(obj, k)}`);
-//     } catch (e) {
-//       // nothing
-//     }
-//   });
-// }


### PR DESCRIPTION
🎯 **What:** Removed commented-out debug function (`printObject`) in `src/utils/profiler/profiler.ts`.
💡 **Why:** Commented out code decreases code readability and maintainability. Version control retains history so this dead code can be safely removed.
✅ **Verification:** Verified by successfully running the project test suite and the build command without any issues. Also received code review approval.
✨ **Result:** Improved codebase cleanliness and reduced unneeded clutter in the file.

---
*PR created automatically by Jules for task [10281694615878433768](https://jules.google.com/task/10281694615878433768) started by @ChineduOzodi*