### PR TITLE
Smarter defense, higher-RCL unlocks, and automated colony expansion

### DIFF
--- a/src/creep-roles/claimer-creep.ts
+++ b/src/creep-roles/claimer-creep.ts
@@ -1,0 +1,78 @@
+/* eslint-disable max-classes-per-file */
+import { CreepRunner } from "prototypes/creep";
+import { ColonyManager, CreepProfiles, CreepRole } from "prototypes/types";
+import { CreepSpawnerImpl } from "prototypes/CreepSpawner";
+import { Logger } from "utils/logger";
+
+/**
+ * Travels to the colony's expansion target room and claims its controller.
+ */
+export class ClaimerCreep extends CreepRunner {
+    public constructor(creep: Creep) {
+        super(creep);
+    }
+
+    public override onRun(): void {
+        const { creep, memory } = this;
+        const targetRoomName = memory.workTargetId;
+
+        if (!targetRoomName) {
+            creep.say("No target");
+            return;
+        }
+
+        if (creep.room.name !== targetRoomName) {
+            this.moveToWithReservation({ pos: new RoomPosition(25, 25, targetRoomName) }, 0, 20);
+            return;
+        }
+
+        const controller = creep.room.controller;
+        if (!controller) {
+            Logger.warning(`[Claimer] ${creep.name}: target room ${targetRoomName} has no controller`);
+            return;
+        }
+
+        if (controller.my) {
+            creep.say("Claimed!");
+            return;
+        }
+
+        const result = creep.claimController(controller);
+        if (result === ERR_NOT_IN_RANGE) {
+            this.moveToWithReservation(controller, 0, 1);
+        } else if (result === ERR_GCL_NOT_ENOUGH) {
+            creep.say("GCL low");
+        } else if (result === OK) {
+            Logger.info(`[Claimer] Claimed room ${targetRoomName} for colony ${memory.colonyId}`);
+        }
+    }
+}
+
+export class ClaimerCreepSpawner extends CreepSpawnerImpl {
+    public onCreateProfiles(_energyBudgetRate: number, colony: ColonyManager): CreepProfiles {
+        const expansion = colony.colonyInfo.expansionManagement;
+        const target = expansion?.expansionTarget;
+        if (!target) return {};
+
+        // Already claimed? No claimer needed.
+        const targetRoom = Game.rooms[target];
+        if (targetRoom?.controller?.my) return {};
+
+        // Can't afford the claim body
+        if (colony.getMainRoom().energyCapacityAvailable < 650) return {};
+
+        return {
+            [`${CreepRole.CLAIMER}-${target}`]: {
+                desiredAmount: 1,
+                bodyBlueprint: [CLAIM, MOVE],
+                memoryBlueprint: {
+                    role: CreepRole.CLAIMER,
+                    workTargetId: target,
+                    workDuration: 0,
+                    averageEnergyConsumptionProductionPerTick: 0,
+                },
+                priority: 4,
+            },
+        };
+    }
+}

--- a/src/creep-roles/defender-creep.ts
+++ b/src/creep-roles/defender-creep.ts
@@ -41,6 +41,20 @@ export class DefenderCreep extends CreepRunner {
         }
 
         if (target) {
+            // Prefer fighting from a rampart: attackers can't hit us through it.
+            if ("body" in target) {
+                const rampart = this.findCombatRampart(target as Creep, 1);
+                if (rampart) {
+                    if (!creep.pos.isEqualTo(rampart.pos)) {
+                        this.moveToWithReservation(rampart, creep.memory.workDuration, 0);
+                    }
+                    if (creep.pos.isNearTo(target)) {
+                        this.attack(target);
+                    }
+                    return;
+                }
+            }
+
             if (this.attack(target) === ERR_NOT_IN_RANGE) {
                 this.moveToWithReservation(target, creep.memory.workDuration);
             }

--- a/src/creep-roles/defender-creep.ts
+++ b/src/creep-roles/defender-creep.ts
@@ -26,7 +26,10 @@ export class DefenderCreep extends CreepRunner {
 
         const threat = ThreatAssessment.assess(this.creep.room);
 
-        let target: AnyCreep | Structure | null = threat.weakestHostile;
+        // Kill healers first — they keep everything else alive. Then fall back to the weakest hostile.
+        const healers = threat.hostiles.filter(h => h.getActiveBodyparts(HEAL) > 0);
+        let target: AnyCreep | Structure | null =
+            healers.length > 0 ? this.creep.pos.findClosestByRange(healers) : threat.weakestHostile;
 
         if (!target) {
             target = this.creep.pos.findClosestByRange(FIND_HOSTILE_STRUCTURES, {

--- a/src/creep-roles/defender-creep.ts
+++ b/src/creep-roles/defender-creep.ts
@@ -24,6 +24,9 @@ export class DefenderCreep extends CreepRunner {
             return;
         }
 
+        // Grab an attack boost first if a lab has one ready
+        if (this.tryBoost(ATTACK)) return;
+
         const threat = ThreatAssessment.assess(this.creep.room);
 
         // Kill healers first — they keep everything else alive. Then fall back to the weakest hostile.

--- a/src/creep-roles/extension-filler-creep.ts
+++ b/src/creep-roles/extension-filler-creep.ts
@@ -2,6 +2,7 @@
 import { CreepRunner } from "prototypes/creep";
 import { ColonyManager, CreepProfiles, CreepRole } from "prototypes/types";
 import { CreepSpawnerImpl } from "prototypes/CreepSpawner";
+import { TERMINAL_ENERGY_RESERVE } from "managers/terminal-manager";
 
 export class ExtensionFillerCreep extends CreepRunner {
     public constructor(creep: Creep) {
@@ -72,13 +73,28 @@ export class ExtensionFillerCreep extends CreepRunner {
                 if (this.transfer(tower, RESOURCE_ENERGY) === ERR_NOT_IN_RANGE) {
                     this.moveToWithReservation(tower, 5);
                 }
-            } else {
-                // Idle near storage
-                const colony = this.getColony();
-                const storage = colony?.getPrimaryStorage();
-                if (storage && !creep.pos.inRangeTo(storage, 3)) {
-                    this.moveToWithReservation(storage, 5, 2);
+                return;
+            }
+
+            // Priority 3: Terminal fee energy (needed to pay market transaction costs)
+            const terminal = creep.room?.terminal;
+            if (
+                terminal &&
+                terminal.isActive() &&
+                terminal.store[RESOURCE_ENERGY] < TERMINAL_ENERGY_RESERVE &&
+                terminal.store.getFreeCapacity() > 0
+            ) {
+                if (this.transfer(terminal, RESOURCE_ENERGY) === ERR_NOT_IN_RANGE) {
+                    this.moveToWithReservation(terminal, 5);
                 }
+                return;
+            }
+
+            // Idle near storage
+            const colony = this.getColony();
+            const storage = colony?.getPrimaryStorage();
+            if (storage && !creep.pos.inRangeTo(storage, 3)) {
+                this.moveToWithReservation(storage, 5, 2);
             }
         }
     }

--- a/src/creep-roles/lab-hauler-creep.ts
+++ b/src/creep-roles/lab-hauler-creep.ts
@@ -1,0 +1,165 @@
+/* eslint-disable max-classes-per-file */
+import { CreepRunner } from "prototypes/creep";
+import { ColonyManager, CreepProfiles, CreepRole } from "prototypes/types";
+import { CreepSpawnerImpl } from "prototypes/CreepSpawner";
+import { INPUT_LAB_TARGET, LAB_ENERGY_TARGET, OUTPUT_LAB_EMPTY_THRESHOLD } from "managers/lab-manager";
+
+type LabTask =
+    | { type: "empty"; lab: StructureLab; resource: ResourceConstant }
+    | { type: "fill"; lab: StructureLab; resource: ResourceConstant };
+
+/**
+ * Keeps the lab pipeline flowing: loads reagents into input labs, empties
+ * products (and stray minerals) into the terminal, and tops up lab energy
+ * for boosting.
+ */
+export class LabHaulerCreep extends CreepRunner {
+    public constructor(creep: Creep) {
+        super(creep);
+    }
+
+    public override onRun(): void {
+        const { creep } = this;
+        const colony = this.getColony();
+        const room = creep.room;
+        const terminal = room.terminal;
+        if (!colony || !terminal) return;
+
+        const task = this.findTask(colony, room);
+
+        if (!task) {
+            if (creep.store.getUsedCapacity() > 0) {
+                this.depositAll(terminal);
+            } else if (!creep.pos.inRangeTo(terminal, 3)) {
+                this.moveToWithReservation(terminal, 5, 2);
+            }
+            return;
+        }
+
+        if (task.type === "empty") {
+            if (
+                creep.store.getFreeCapacity() === 0 ||
+                (creep.store.getUsedCapacity() > 0 && !creep.store[task.resource])
+            ) {
+                this.depositAll(terminal);
+                return;
+            }
+            if (this.withdraw(task.lab, task.resource) === ERR_NOT_IN_RANGE) {
+                this.moveToWithReservation(task.lab, 5);
+            }
+            return;
+        }
+
+        // fill task
+        if (creep.store[task.resource] > 0) {
+            if (this.transfer(task.lab, task.resource) === ERR_NOT_IN_RANGE) {
+                this.moveToWithReservation(task.lab, 5);
+            }
+            return;
+        }
+        if (creep.store.getUsedCapacity() > 0) {
+            this.depositAll(terminal);
+            return;
+        }
+
+        const source = this.findSupply(room, task.resource);
+        if (source) {
+            if (this.withdraw(source, task.resource) === ERR_NOT_IN_RANGE) {
+                this.moveToWithReservation(source, 5);
+            }
+        }
+    }
+
+    private findTask(colony: ColonyManager, room: Room): LabTask | null {
+        const info = colony.colonyInfo.labManagement;
+        const labs = room.find<StructureLab>(FIND_MY_STRUCTURES, {
+            filter: s => s.structureType === STRUCTURE_LAB,
+        });
+        if (labs.length === 0) return null;
+
+        const inputIds = info?.inputLabIds || [];
+        const reagents = info?.reagents || [];
+        const product = info?.product;
+
+        for (const lab of labs) {
+            const isInput = inputIds.includes(lab.id);
+            const expected = isInput ? reagents[inputIds.indexOf(lab.id)] : product;
+
+            // 1. Wrong mineral anywhere -> clear it out
+            if (lab.mineralType && lab.mineralType !== expected) {
+                return { type: "empty", lab, resource: lab.mineralType };
+            }
+        }
+
+        // 2. Output labs with enough product -> bank it
+        for (const lab of labs) {
+            if (inputIds.includes(lab.id)) continue;
+            if (product && lab.mineralType === product && lab.store[product] >= OUTPUT_LAB_EMPTY_THRESHOLD) {
+                return { type: "empty", lab, resource: product };
+            }
+        }
+
+        // 3. Input labs running low -> restock
+        for (let i = 0; i < inputIds.length; i++) {
+            const lab = Game.getObjectById(inputIds[i]);
+            const reagent = reagents[i];
+            if (!lab || !reagent) continue;
+            if ((lab.store[reagent] || 0) < INPUT_LAB_TARGET && this.findSupply(room, reagent)) {
+                return { type: "fill", lab, resource: reagent };
+            }
+        }
+
+        // 4. Keep some energy in labs for boosting
+        for (const lab of labs) {
+            if (lab.store[RESOURCE_ENERGY] < LAB_ENERGY_TARGET && this.findSupply(room, RESOURCE_ENERGY)) {
+                return { type: "fill", lab, resource: RESOURCE_ENERGY };
+            }
+        }
+
+        return null;
+    }
+
+    private findSupply(room: Room, resource: ResourceConstant): StructureTerminal | StructureStorage | null {
+        if (room.terminal && (room.terminal.store[resource] || 0) > 0) return room.terminal;
+        if (room.storage && (room.storage.store[resource] || 0) > 0) return room.storage;
+        return null;
+    }
+
+    private depositAll(terminal: StructureTerminal): void {
+        const { creep } = this;
+        for (const resourceType in creep.store) {
+            const result = this.transfer(terminal, resourceType as ResourceConstant);
+            if (result === ERR_NOT_IN_RANGE) {
+                this.moveToWithReservation(terminal, 5);
+                return;
+            }
+            if (result !== OK) return;
+        }
+    }
+}
+
+export class LabHaulerCreepSpawner extends CreepSpawnerImpl {
+    public onCreateProfiles(_energyBudgetRate: number, colony: ColonyManager): CreepProfiles {
+        const room = colony.getMainRoom();
+        if (!room || !room.controller || (room.controller.level || 0) < 6) return {};
+        if (!room.terminal || typeof room.find !== "function") return {};
+
+        const labs = room.find(FIND_MY_STRUCTURES, {
+            filter: s => s.structureType === STRUCTURE_LAB,
+        });
+        if (labs.length < 3) return {};
+
+        return {
+            [CreepRole.LAB_HAULER]: {
+                desiredAmount: 1,
+                bodyBlueprint: [CARRY, CARRY, CARRY, CARRY, MOVE, MOVE, MOVE, MOVE],
+                memoryBlueprint: {
+                    role: CreepRole.LAB_HAULER,
+                    workDuration: 10,
+                    averageEnergyConsumptionProductionPerTick: 0,
+                },
+                priority: 1,
+            },
+        };
+    }
+}

--- a/src/creep-roles/mineral-miner-creep.ts
+++ b/src/creep-roles/mineral-miner-creep.ts
@@ -1,0 +1,128 @@
+/* eslint-disable max-classes-per-file */
+import { CreepRunner } from "prototypes/creep";
+import { ColonyManager, CreepProfiles, CreepRole } from "prototypes/types";
+import { CreepSpawnerImpl } from "prototypes/CreepSpawner";
+
+/**
+ * Mines the room's mineral (via an extractor) and hauls it to the terminal,
+ * falling back to storage. Only spawned when the extractor exists and the
+ * mineral has anything left.
+ */
+export class MineralMinerCreep extends CreepRunner {
+    public constructor(creep: Creep) {
+        super(creep);
+    }
+
+    public override onRun(): void {
+        const { creep, memory } = this;
+
+        if (memory.working && creep.store.getUsedCapacity() === 0) {
+            memory.working = false;
+        }
+        if (!memory.working && creep.store.getFreeCapacity() === 0) {
+            memory.working = true;
+        }
+
+        if (memory.working) {
+            this.deliverMinerals();
+        } else {
+            this.mineMineral();
+        }
+    }
+
+    private mineMineral(): void {
+        const { creep, memory } = this;
+        const mineral = memory.workTargetId ? Game.getObjectById<Mineral>(memory.workTargetId as Id<Mineral>) : null;
+
+        if (!mineral || mineral.mineralAmount === 0) {
+            // Nothing left to mine; dump what we carry and idle.
+            if (creep.store.getUsedCapacity() > 0) {
+                memory.working = true;
+            } else {
+                creep.say("depleted");
+            }
+            return;
+        }
+
+        if (this.harvest(mineral) === ERR_NOT_IN_RANGE) {
+            this.moveToWithReservation(mineral, creep.memory.workDuration, 1);
+        }
+    }
+
+    private deliverMinerals(): void {
+        const { creep } = this;
+        const room = creep.room;
+
+        const target =
+            room.terminal && room.terminal.isActive() && room.terminal.store.getFreeCapacity() > 0
+                ? room.terminal
+                : room.storage;
+
+        if (!target) {
+            creep.say("no dropoff");
+            return;
+        }
+
+        for (const resourceType in creep.store) {
+            const result = this.transfer(target, resourceType as ResourceConstant);
+            if (result === ERR_NOT_IN_RANGE) {
+                this.moveToWithReservation(target, creep.memory.workDuration, 1);
+                return;
+            }
+            if (result !== OK) return;
+        }
+    }
+}
+
+export class MineralMinerCreepSpawner extends CreepSpawnerImpl {
+    public onCreateProfiles(_energyBudgetRate: number, colony: ColonyManager): CreepProfiles {
+        const room = colony.getMainRoom();
+        if (!room || !room.controller || room.controller.level < 6) return {};
+
+        // Need somewhere to put the minerals
+        if (!room.storage && !room.terminal) return {};
+
+        const minerals = room.find(FIND_MINERALS);
+        const profiles: CreepProfiles = {};
+
+        for (const mineral of minerals) {
+            if (mineral.mineralAmount === 0) continue;
+
+            const hasExtractor = mineral.pos
+                .lookFor(LOOK_STRUCTURES)
+                .some(s => s.structureType === STRUCTURE_EXTRACTOR);
+            if (!hasExtractor) continue;
+
+            profiles[`${CreepRole.MINERAL_MINER}-${mineral.id}`] = this.createProfile(mineral, colony);
+        }
+
+        return profiles;
+    }
+
+    private createProfile(mineral: Mineral, colony: ColonyManager): CreepSpawnerProfileInfo {
+        const energyCap = colony.getMainRoom().energyCapacityAvailable;
+
+        // [WORK, WORK, CARRY, MOVE] units: mine fast, haul in batches.
+        const unitCost = 300;
+        let units = Math.floor(energyCap / unitCost);
+        units = Math.min(units, 8);
+        if (units < 1) units = 1;
+
+        const body: BodyPartConstant[] = [];
+        for (let i = 0; i < units; i++) {
+            body.push(WORK, WORK, CARRY, MOVE);
+        }
+
+        return {
+            desiredAmount: 1,
+            bodyBlueprint: body,
+            memoryBlueprint: {
+                role: CreepRole.MINERAL_MINER,
+                workTargetId: mineral.id,
+                workDuration: 20,
+                averageEnergyConsumptionProductionPerTick: 0,
+            },
+            priority: 1, // Low priority — economy and defense come first
+        };
+    }
+}

--- a/src/creep-roles/pioneer-creep.ts
+++ b/src/creep-roles/pioneer-creep.ts
@@ -1,0 +1,136 @@
+/* eslint-disable max-classes-per-file */
+import { CreepRunner } from "prototypes/creep";
+import { ColonyManager, CreepProfiles, CreepRole } from "prototypes/types";
+import { CreepSpawnerImpl } from "prototypes/CreepSpawner";
+
+/**
+ * Bootstraps a freshly claimed room: harvests local energy, builds the first
+ * spawn, and keeps the controller from downgrading. Once the new spawn exists,
+ * the room becomes a self-sufficient colony and pioneers phase out.
+ */
+export class PioneerCreep extends CreepRunner {
+    public constructor(creep: Creep) {
+        super(creep);
+    }
+
+    public override onRun(): void {
+        const { creep, memory } = this;
+        const targetRoomName = memory.workTargetId;
+
+        if (!targetRoomName) {
+            creep.say("No target");
+            return;
+        }
+
+        if (creep.room.name !== targetRoomName) {
+            this.moveToWithReservation({ pos: new RoomPosition(25, 25, targetRoomName) }, 0, 20);
+            return;
+        }
+
+        // Cycle state
+        if (memory.working && creep.store[RESOURCE_ENERGY] === 0) {
+            memory.working = false;
+            this.removeTarget();
+        }
+        if (!memory.working && creep.store.getFreeCapacity() === 0) {
+            memory.working = true;
+            this.removeTarget();
+        }
+
+        if (memory.working) {
+            this.doWork();
+        } else {
+            this.gatherLocalEnergy();
+        }
+    }
+
+    private doWork(): void {
+        const { creep } = this;
+        const room = creep.room;
+
+        // Priority 1: Build the spawn (or any other site while we're at it)
+        const spawnSite = room.find(FIND_MY_CONSTRUCTION_SITES, {
+            filter: s => s.structureType === STRUCTURE_SPAWN,
+        })[0];
+        const site = spawnSite || room.find(FIND_MY_CONSTRUCTION_SITES)[0];
+
+        if (site) {
+            if (this.build(site) === ERR_NOT_IN_RANGE) {
+                this.moveToWithReservation(site, creep.memory.workDuration, 3);
+            }
+            return;
+        }
+
+        // Priority 2: Upgrade the controller so RCL1 doesn't stall/downgrade
+        if (room.controller && room.controller.my) {
+            if (this.upgradeController(room.controller) === ERR_NOT_IN_RANGE) {
+                this.moveToWithReservation(room.controller, creep.memory.workDuration, 3);
+            }
+        }
+    }
+
+    private gatherLocalEnergy(): void {
+        const { creep } = this;
+
+        // Prefer scavenging, then harvest a source in the new room.
+        const dropped = this.findClosestDroppedEnergy(40);
+        if (dropped) {
+            if (this.pickup(dropped) === ERR_NOT_IN_RANGE) {
+                this.moveToWithReservation(dropped, creep.memory.workDuration);
+            }
+            return;
+        }
+
+        const source = this.findClosestSource(0);
+        if (source) {
+            if (this.harvest(source) === ERR_NOT_IN_RANGE) {
+                this.moveToWithReservation(source, creep.memory.workDuration);
+            }
+        } else {
+            creep.say("no energy");
+        }
+    }
+}
+
+export class PioneerCreepSpawner extends CreepSpawnerImpl {
+    public onCreateProfiles(_energyBudgetRate: number, colony: ColonyManager): CreepProfiles {
+        const expansion = colony.colonyInfo.expansionManagement;
+        const target = expansion?.expansionTarget;
+        if (!target) return {};
+
+        // Pioneers are only useful once the room is claimed and until its first spawn is running.
+        const targetRoom = Game.rooms[target];
+        if (!targetRoom || !targetRoom.controller || !targetRoom.controller.my) return {};
+        if (targetRoom.find(FIND_MY_SPAWNS).length > 0) return {};
+
+        const body = this.createPioneerBody(colony.getMainRoom().energyCapacityAvailable);
+
+        return {
+            [`${CreepRole.PIONEER}-${target}`]: {
+                desiredAmount: 3,
+                bodyBlueprint: body,
+                memoryBlueprint: {
+                    role: CreepRole.PIONEER,
+                    workTargetId: target,
+                    workDuration: 20,
+                    averageEnergyConsumptionProductionPerTick: 0,
+                },
+                priority: 3,
+            },
+        };
+    }
+
+    private createPioneerBody(energyCap: number): BodyPartConstant[] {
+        // [WORK, CARRY, MOVE, MOVE] = 250: full-speed travel on plains even when loaded.
+        const unitCost = 250;
+        let units = Math.floor(energyCap / unitCost);
+        units = Math.min(units, 6);
+        if (units < 1) units = 1;
+
+        const body: BodyPartConstant[] = [];
+        for (let i = 0; i < units; i++) {
+            body.push(WORK, CARRY, MOVE, MOVE);
+        }
+        return body;
+    }
+}

--- a/src/creep-roles/ranged-defender-creep.ts
+++ b/src/creep-roles/ranged-defender-creep.ts
@@ -1,0 +1,128 @@
+/* eslint-disable max-classes-per-file */
+import { CreepRunner } from "prototypes/creep";
+import { ColonyManager, CreepProfiles, CreepRole } from "prototypes/types";
+import { CreepSpawnerImpl } from "prototypes/CreepSpawner";
+import { EnergyCalculator } from "utils/energy-calculator";
+import { ThreatAssessment } from "utils/threat-assessment";
+
+const BASE_RANGED_DEFENDER: BodyPartConstant[] = [RANGED_ATTACK, MOVE];
+
+/**
+ * Kiting defender: keeps at range 3 from melee attackers while shooting,
+ * so slow boosted melee creeps can never land a hit.
+ */
+export class RangedDefenderCreep extends CreepRunner {
+    public constructor(creep: Creep) {
+        super(creep);
+    }
+
+    public override onRun(): void {
+        const { creep } = this;
+        const targetRoomName = creep.memory.homeRoomName;
+
+        if (targetRoomName && creep.room.name !== targetRoomName) {
+            this.moveToWithReservation({ pos: new RoomPosition(25, 25, targetRoomName) }, 0, 20);
+            return;
+        }
+
+        // Grab a ranged boost first if a lab has one ready
+        if (this.tryBoost(RANGED_ATTACK)) return;
+
+        const threat = ThreatAssessment.assess(creep.room);
+
+        // Target priority: healers, then the weakest hostile
+        const healers = threat.hostiles.filter(h => h.getActiveBodyparts(HEAL) > 0);
+        const target: Creep | null = healers.length > 0 ? creep.pos.findClosestByRange(healers) : threat.weakestHostile;
+
+        if (!target) {
+            const hostileStructure = creep.pos.findClosestByRange(FIND_HOSTILE_STRUCTURES, {
+                filter: s => s.structureType !== STRUCTURE_CONTROLLER,
+            });
+            if (hostileStructure) {
+                if (creep.rangedAttack(hostileStructure) === ERR_NOT_IN_RANGE) {
+                    this.moveToWithReservation(hostileStructure, creep.memory.workDuration, 3);
+                }
+            } else if (targetRoomName && this.colony && this.colony.colonyInfo.rooms[targetRoomName]) {
+                this.colony.colonyInfo.rooms[targetRoomName].alertLevel = 0;
+            }
+            return;
+        }
+
+        // Shoot: mass attack when swarmed, otherwise focus the target
+        const inCloseRange = creep.pos.findInRange(FIND_HOSTILE_CREEPS, 1);
+        if (inCloseRange.length >= 2) {
+            creep.rangedMassAttack();
+        } else if (creep.pos.inRangeTo(target, 3)) {
+            creep.rangedAttack(target);
+        }
+
+        // Movement: kite away from anything that can melee us, else close to range 3
+        const dangerClose = creep.pos.findInRange(FIND_HOSTILE_CREEPS, 2, {
+            filter: h => h.getActiveBodyparts(ATTACK) > 0,
+        });
+
+        if (dangerClose.length > 0) {
+            this.fleeFrom(dangerClose[0]);
+        } else if (!creep.pos.inRangeTo(target, 3)) {
+            this.moveToWithReservation(target, creep.memory.workDuration, 3);
+        }
+    }
+
+    private fleeFrom(hostile: Creep): void {
+        const { creep } = this;
+        const dir = creep.pos.getDirectionTo(hostile);
+        // Opposite of dir (directions are 1..8 clockwise)
+        const away = (((dir - 1 + 4) % 8) + 1) as DirectionConstant;
+        creep.move(away);
+        delete creep.memory.movementSystem?.path;
+    }
+}
+
+export class RangedDefenderCreepSpawner extends CreepSpawnerImpl {
+    public onCreateProfiles(_energyCap: number, colony: ColonyManager): CreepProfiles {
+        const rooms = colony.colonyInfo.rooms;
+        const profiles: CreepProfiles = {};
+
+        for (const roomName in rooms) {
+            const roomInfo = rooms[roomName];
+            if (roomInfo.alertLevel <= 0) continue;
+
+            // Melee defenders handle small incursions; ranged join for bigger ones.
+            const desiredAmount = Math.floor(roomInfo.alertLevel / 2);
+            if (desiredAmount <= 0) continue;
+
+            const profileName = `${CreepRole.RANGED_DEFENDER}-${roomInfo.name}`;
+            profiles[profileName] = this.createProfile(roomInfo.name, colony);
+            profiles[profileName].desiredAmount = desiredAmount;
+        }
+        return profiles;
+    }
+
+    private createProfile(roomName: string, colony: ColonyManager): CreepSpawnerProfileInfo {
+        const room = colony.getMainRoom();
+        let energy = room.energyCapacityAvailable;
+        if (colony.systems.energy.noEnergyCollectors()) {
+            energy = room.energyAvailable;
+        }
+        const targetEnergy = Math.min(energy, 2000);
+
+        const unitCost = CreepSpawnerImpl.getSpawnBodyEnergyCost(BASE_RANGED_DEFENDER);
+        const units = Math.max(1, Math.floor(targetEnergy / unitCost));
+        const body = CreepSpawnerImpl.multiplyBody(BASE_RANGED_DEFENDER, units);
+
+        const cost = EnergyCalculator.calculateBodyCost(body);
+
+        return {
+            desiredAmount: 0,
+            bodyBlueprint: body,
+            memoryBlueprint: {
+                homeRoomName: roomName,
+                workTargetId: roomName,
+                workDuration: 5,
+                role: CreepRole.RANGED_DEFENDER,
+                averageEnergyConsumptionProductionPerTick: cost / CREEP_LIFE_TIME,
+            },
+            priority: 10,
+        };
+    }
+}

--- a/src/creep-roles/ranged-defender-creep.ts
+++ b/src/creep-roles/ranged-defender-creep.ts
@@ -56,7 +56,18 @@ export class RangedDefenderCreep extends CreepRunner {
             creep.rangedAttack(target);
         }
 
-        // Movement: kite away from anything that can melee us, else close to range 3
+        // Movement: a rampart in firing range beats kiting — nothing can hit us there.
+        const rampart = this.findCombatRampart(target, 3);
+        if (rampart) {
+            if (!creep.pos.isEqualTo(rampart.pos)) {
+                this.moveToWithReservation(rampart, creep.memory.workDuration, 0);
+            }
+            return;
+        }
+
+        // Otherwise kite away from anything that can melee us, else close to range 3
+        if (this.isOnOwnRampart()) return; // Safe where we stand
+
         const dangerClose = creep.pos.findInRange(FIND_HOSTILE_CREEPS, 2, {
             filter: h => h.getActiveBodyparts(ATTACK) > 0,
         });

--- a/src/creep-roles/scout-creep.ts
+++ b/src/creep-roles/scout-creep.ts
@@ -63,6 +63,13 @@ export class ScoutCreepSpawner extends CreepSpawnerImpl {
         const room = colony.getMainRoom();
         if (!room || !room.controller || room.controller.level < 2) return {};
 
+        // An observer scouts for free — no need for scout creeps.
+        if (typeof room.find === "function") {
+            const hasObserver =
+                room.find(FIND_MY_STRUCTURES, { filter: s => s.structureType === STRUCTURE_OBSERVER }).length > 0;
+            if (hasObserver) return {};
+        }
+
         const roomsNeedingScout = RoomUtils.getRoomsNeedingScout(colony);
         if (roomsNeedingScout.length === 0) return {};
 

--- a/src/management/creep-management.ts
+++ b/src/management/creep-management.ts
@@ -16,6 +16,8 @@ import { ReserverCreep } from "creep-roles/reserver-creep";
 import { MineralMinerCreep } from "creep-roles/mineral-miner-creep";
 import { ClaimerCreep } from "creep-roles/claimer-creep";
 import { PioneerCreep } from "creep-roles/pioneer-creep";
+import { RangedDefenderCreep } from "creep-roles/ranged-defender-creep";
+import { LabHaulerCreep } from "creep-roles/lab-hauler-creep";
 import { Logger } from "utils/logger";
 
 export class CreepManagement {
@@ -80,6 +82,10 @@ export class CreepManagement {
                 return new ClaimerCreep(creep);
             case CreepRole.PIONEER:
                 return new PioneerCreep(creep);
+            case CreepRole.RANGED_DEFENDER:
+                return new RangedDefenderCreep(creep);
+            case CreepRole.LAB_HAULER:
+                return new LabHaulerCreep(creep);
             default:
                 Logger.error(`creep (${creep.name}) role "${creep.memory.role}" not setup`);
                 return;

--- a/src/management/creep-management.ts
+++ b/src/management/creep-management.ts
@@ -13,6 +13,9 @@ import { RepairerCreep } from "./../creep-roles/repairer-creep";
 import { UpgraderCreep } from "creep-roles/upgrader-creep";
 import { ScoutCreep } from "creep-roles/scout-creep";
 import { ReserverCreep } from "creep-roles/reserver-creep";
+import { MineralMinerCreep } from "creep-roles/mineral-miner-creep";
+import { ClaimerCreep } from "creep-roles/claimer-creep";
+import { PioneerCreep } from "creep-roles/pioneer-creep";
 import { Logger } from "utils/logger";
 
 export class CreepManagement {
@@ -71,6 +74,12 @@ export class CreepManagement {
                 return new ScoutCreep(creep);
             case CreepRole.RESERVER:
                 return new ReserverCreep(creep);
+            case CreepRole.MINERAL_MINER:
+                return new MineralMinerCreep(creep);
+            case CreepRole.CLAIMER:
+                return new ClaimerCreep(creep);
+            case CreepRole.PIONEER:
+                return new PioneerCreep(creep);
             default:
                 Logger.error(`creep (${creep.name}) role "${creep.memory.role}" not setup`);
                 return;

--- a/src/managers/construction-manager.ts
+++ b/src/managers/construction-manager.ts
@@ -1,5 +1,6 @@
 import { ColonyManager } from "../prototypes/types";
 import { ConstructionUtils } from "../utils/construction-utils";
+import { MinCut } from "../utils/min-cut";
 import { REPAIR_THRESHOLD_DECAY_PREVENTION, REPAIR_THRESHOLD_EMERGENCY } from "../constants/repair-constants";
 import { RepairUtils } from "../utils/repair-utils";
 import { Logger } from "../utils/logger";
@@ -62,7 +63,76 @@ export class ConstructionManager {
             this.planFactory();
             this.planObserver();
             this.planRamparts();
+            this.planPerimeter();
         }
+    }
+
+    /**
+     * Plans a min-cut rampart perimeter that seals the base off from all exits.
+     * Computed once per RCL (structures shift as the base grows) and built gradually.
+     */
+    private planPerimeter(): void {
+        const room = this.colony.getMainRoom();
+        if (!room || !room.controller || (room.controller.level || 0) < 4) return;
+        if (typeof room.getTerrain !== "function") return;
+
+        const defense = this.colony.colonyInfo.defenseManagement;
+        if (!defense) return;
+
+        const rcl = room.controller.level;
+        if (!defense.perimeter || defense.lastPerimeterRcl !== rcl) {
+            defense.perimeter = this.computePerimeter(room);
+            defense.lastPerimeterRcl = rcl;
+            if (defense.perimeter.length > 0) {
+                Logger.info(`[Perimeter] ${room.name}: planned ${defense.perimeter.length} rampart positions`);
+            }
+        }
+
+        // Build gradually: a few sites at a time so we don't flood the build queue.
+        let placed = 0;
+        for (const tile of defense.perimeter) {
+            if (placed >= 5) break;
+            if (Object.keys(Game.constructionSites).length >= 100) break;
+
+            const pos = new RoomPosition(tile.x, tile.y, room.name);
+            const hasRampart = pos.lookFor(LOOK_STRUCTURES).some(s => s.structureType === STRUCTURE_RAMPART);
+            const hasSite = pos.lookFor(LOOK_CONSTRUCTION_SITES).some(s => s.structureType === STRUCTURE_RAMPART);
+            if (hasRampart || hasSite) continue;
+
+            if (room.createConstructionSite(pos, STRUCTURE_RAMPART) === OK) {
+                placed++;
+            }
+        }
+    }
+
+    private computePerimeter(room: Room): { x: number; y: number }[] {
+        const protectedTypes: StructureConstant[] = [
+            STRUCTURE_SPAWN,
+            STRUCTURE_EXTENSION,
+            STRUCTURE_TOWER,
+            STRUCTURE_STORAGE,
+            STRUCTURE_TERMINAL,
+            STRUCTURE_LAB,
+            STRUCTURE_FACTORY,
+        ];
+        const positions = room
+            .find(FIND_MY_STRUCTURES, { filter: s => protectedTypes.includes(s.structureType) })
+            .map(s => ({ x: s.pos.x, y: s.pos.y }));
+
+        if (positions.length === 0) return [];
+
+        // Try to protect the controller too; fall back to just the core if that
+        // pushes the protected area into an exit zone.
+        const withController = room.controller
+            ? [...positions, { x: room.controller.pos.x, y: room.controller.pos.y }]
+            : positions;
+
+        const terrain = room.getTerrain();
+        let cut = MinCut.computeCut(terrain, MinCut.getProtectedRects(withController, 3), TERRAIN_MASK_WALL);
+        if (cut.length === 0 && withController.length !== positions.length) {
+            cut = MinCut.computeCut(terrain, MinCut.getProtectedRects(positions, 3), TERRAIN_MASK_WALL);
+        }
+        return cut;
     }
 
     /** Places ramparts over critical structures so they survive sieges. */

--- a/src/managers/construction-manager.ts
+++ b/src/managers/construction-manager.ts
@@ -58,7 +58,91 @@ export class ConstructionManager {
             this.planLinks();
             this.planExtractor();
             this.planTerminal();
+            this.planLabs();
+            this.planFactory();
+            this.planObserver();
+            this.planRamparts();
         }
+    }
+
+    /** Places ramparts over critical structures so they survive sieges. */
+    private planRamparts(): void {
+        const room = this.colony.getMainRoom();
+        if (!room || !room.controller || (room.controller.level || 0) < 3) return;
+
+        const protectedTypes: StructureConstant[] = [
+            STRUCTURE_SPAWN,
+            STRUCTURE_TOWER,
+            STRUCTURE_STORAGE,
+            STRUCTURE_TERMINAL,
+            STRUCTURE_LAB,
+            STRUCTURE_FACTORY,
+            STRUCTURE_POWER_SPAWN,
+            STRUCTURE_NUKER,
+        ];
+
+        const criticalStructures = room.find(FIND_MY_STRUCTURES, {
+            filter: s => protectedTypes.includes(s.structureType),
+        });
+
+        for (const structure of criticalStructures) {
+            if (Object.keys(Game.constructionSites).length >= 100) break;
+
+            const pos = structure.pos;
+            const hasRampart = pos.lookFor(LOOK_STRUCTURES).some(s => s.structureType === STRUCTURE_RAMPART);
+            const hasRampartSite = pos
+                .lookFor(LOOK_CONSTRUCTION_SITES)
+                .some(s => s.structureType === STRUCTURE_RAMPART);
+
+            if (!hasRampart && !hasRampartSite) {
+                room.createConstructionSite(pos, STRUCTURE_RAMPART);
+            }
+        }
+    }
+
+    private planLabs(): void {
+        const room = this.colony.getMainRoom();
+        const spawn = this.colony.getMainSpawn();
+        if (!room || !spawn || !room.controller || (room.controller.level || 0) < 6) return;
+
+        const rcl = room.controller.level;
+        const maxLabs = (CONTROLLER_STRUCTURES[STRUCTURE_LAB] || {})[rcl] || 0;
+        if (maxLabs === 0 || this.hasPlannedStructures(STRUCTURE_LAB, maxLabs)) return;
+        if (Object.keys(Game.constructionSites).length >= 100) return;
+
+        const currentCount =
+            room.find(FIND_MY_STRUCTURES, { filter: s => s.structureType === STRUCTURE_LAB }).length +
+            room.find(FIND_MY_CONSTRUCTION_SITES, { filter: s => s.structureType === STRUCTURE_LAB }).length;
+
+        const needed = maxLabs - currentCount;
+        if (needed <= 0) return;
+
+        const structures = ConstructionUtils.getClusteredStructures(spawn, room, STRUCTURE_LAB, needed);
+        this.placeConstructionSites(structures);
+    }
+
+    private planFactory(): void {
+        const room = this.colony.getMainRoom();
+        const spawn = this.colony.getMainSpawn();
+        if (!room || !spawn || !room.controller || (room.controller.level || 0) < 7) return;
+
+        if (this.hasPlannedStructures(STRUCTURE_FACTORY, 1)) return;
+        if (Object.keys(Game.constructionSites).length >= 100) return;
+
+        const structures = ConstructionUtils.getClusteredStructures(spawn, room, STRUCTURE_FACTORY, 1);
+        this.placeConstructionSites(structures);
+    }
+
+    private planObserver(): void {
+        const room = this.colony.getMainRoom();
+        const spawn = this.colony.getMainSpawn();
+        if (!room || !spawn || !room.controller || (room.controller.level || 0) < 8) return;
+
+        if (this.hasPlannedStructures(STRUCTURE_OBSERVER, 1)) return;
+        if (Object.keys(Game.constructionSites).length >= 100) return;
+
+        const structures = ConstructionUtils.getClusteredStructures(spawn, room, STRUCTURE_OBSERVER, 1);
+        this.placeConstructionSites(structures);
     }
 
     private planTerminal(): void {

--- a/src/managers/lab-manager.test.ts
+++ b/src/managers/lab-manager.test.ts
@@ -1,0 +1,78 @@
+import { expect } from "chai";
+import { LabManager } from "./lab-manager";
+
+describe("LabManager", () => {
+    beforeEach(() => {
+        (global as any).REACTIONS = {
+            H: { O: "OH" },
+            O: { H: "OH" },
+            U: { H: "UH", O: "UO" },
+            L: { O: "LO" },
+            K: { O: "KO" },
+        };
+        (global as any).ATTACK = "attack";
+        (global as any).RANGED_ATTACK = "ranged_attack";
+        (global as any).HEAL = "heal";
+        (global as any).TOUGH = "tough";
+        (global as any).MOVE = "move";
+        (global as any).FIND_MY_STRUCTURES = "myStructures";
+        (global as any).STRUCTURE_LAB = "lab";
+        (global as any).RESOURCE_ENERGY = "energy";
+        (global as any).LAB_BOOST_MINERAL = 30;
+        (global as any).LAB_BOOST_ENERGY = 20;
+    });
+
+    describe("reagentsForProduct", () => {
+        it("should find the reagent pair for a product", () => {
+            expect(LabManager.reagentsForProduct("UH" as ResourceConstant)).to.deep.equal(["U", "H"]);
+            expect(LabManager.reagentsForProduct("LO" as ResourceConstant)).to.deep.equal(["L", "O"]);
+        });
+
+        it("should return null for unknown products", () => {
+            expect(LabManager.reagentsForProduct("XYZ" as ResourceConstant)).to.equal(null);
+        });
+    });
+
+    describe("findBoostLab", () => {
+        const makeLab = (mineralType: string | undefined, mineralAmount: number, energy: number): any => ({
+            structureType: "lab",
+            mineralType,
+            store: {
+                [mineralType || ""]: mineralAmount,
+                energy,
+            },
+        });
+
+        it("should find a lab holding a matching boost with enough compound and energy", () => {
+            const uhLab = makeLab("UH", 300, 600);
+            const room: any = {
+                find: () => [makeLab(undefined, 0, 0), uhLab],
+            };
+            // 10 attack parts need 300 mineral and 200 energy
+            expect(LabManager.findBoostLab(room, ATTACK, 10)).to.equal(uhLab);
+        });
+
+        it("should return null when the lab lacks enough compound", () => {
+            const room: any = {
+                find: () => [makeLab("UH", 100, 600)],
+            };
+            expect(LabManager.findBoostLab(room, ATTACK, 10)).to.equal(null);
+        });
+
+        it("should prefer higher-tier boosts when available", () => {
+            const uhLab = makeLab("UH", 900, 900);
+            const xLab = makeLab("XUH2O", 900, 900);
+            const room: any = {
+                find: () => [uhLab, xLab],
+            };
+            expect(LabManager.findBoostLab(room, ATTACK, 10)).to.equal(xLab);
+        });
+
+        it("should return null for parts with no boost mapping", () => {
+            const room: any = {
+                find: () => [makeLab("UH", 900, 900)],
+            };
+            expect(LabManager.findBoostLab(room, "carry" as BodyPartConstant, 5)).to.equal(null);
+        });
+    });
+});

--- a/src/managers/lab-manager.ts
+++ b/src/managers/lab-manager.ts
@@ -1,0 +1,185 @@
+import { ColonyManager } from "../prototypes/types";
+import { Logger } from "../utils/logger";
+
+/** Stop producing a compound once we hold this much. */
+export const COMPOUND_TARGET_AMOUNT = 3000;
+/** Minimum of each reagent on hand before starting a reaction. */
+export const REAGENT_MIN_AMOUNT = 500;
+/** Input labs are restocked below this level. */
+export const INPUT_LAB_TARGET = 1000;
+/** Output labs are emptied above this level. */
+export const OUTPUT_LAB_EMPTY_THRESHOLD = 500;
+/** Labs keep this much energy on hand for boosting. */
+export const LAB_ENERGY_TARGET = 1000;
+
+/**
+ * Compounds we want, in priority order — combat boosts for the creeps we field,
+ * plus the OH / tier-2 chain that upgrades them.
+ */
+const PRODUCT_PRIORITIES: ResourceConstant[] = [
+    "UH" as ResourceConstant, // +attack
+    "KO" as ResourceConstant, // +ranged attack
+    "LO" as ResourceConstant, // +heal
+    "GO" as ResourceConstant, // +tough (damage reduction)
+    "ZO" as ResourceConstant, // +move
+    "OH" as ResourceConstant, // tier-2 ingredient
+    "UH2O" as ResourceConstant,
+    "KHO2" as ResourceConstant,
+    "LHO2" as ResourceConstant,
+    "GHO2" as ResourceConstant,
+];
+
+/** Boost compounds by body part, best first. */
+const BOOSTS_BY_PART: { [part: string]: string[] } = {
+    [ATTACK]: ["XUH2O", "UH2O", "UH"],
+    [RANGED_ATTACK]: ["XKHO2", "KHO2", "KO"],
+    [HEAL]: ["XLHO2", "LHO2", "LO"],
+    [TOUGH]: ["XGHO2", "GHO2", "GO"],
+    [MOVE]: ["XZHO2", "ZHO2", "ZO"],
+};
+
+export class LabManager {
+    private colony: ColonyManager;
+
+    constructor(colony: ColonyManager) {
+        this.colony = colony;
+    }
+
+    private get systemInfo(): ColonyLabManagement {
+        if (!this.colony.colonyInfo.labManagement) {
+            this.colony.colonyInfo.labManagement = { nextUpdate: 0 };
+        }
+        return this.colony.colonyInfo.labManagement;
+    }
+
+    public run(): void {
+        if (Game.time % 10 !== 0) return;
+
+        const room = this.colony.getMainRoom();
+        if (!room || !room.controller || (room.controller.level || 0) < 6) return;
+        if (typeof room.find !== "function") return;
+
+        const labs = room.find<StructureLab>(FIND_MY_STRUCTURES, {
+            filter: s => s.structureType === STRUCTURE_LAB,
+        });
+        if (labs.length < 3) return;
+
+        const info = this.systemInfo;
+
+        // (Re)assign roles and pick a reaction periodically
+        if (Game.time >= (info.nextUpdate || 0)) {
+            this.assignLabs(labs);
+            this.selectReaction();
+            info.nextUpdate = Game.time + 200;
+        }
+
+        this.runReactions(labs);
+    }
+
+    private assignLabs(labs: StructureLab[]): void {
+        const info = this.systemInfo;
+        const existing = (info.inputLabIds || []).filter(id => Game.getObjectById(id));
+        if (existing.length === 2) return;
+
+        // Pick the two labs with the most lab neighbors in range 2 as inputs,
+        // so every output lab is likely in range of both.
+        const scored = labs
+            .map(lab => ({
+                lab,
+                neighbors: labs.filter(o => o.id !== lab.id && lab.pos.inRangeTo(o.pos, 2)).length,
+            }))
+            .sort((a, b) => b.neighbors - a.neighbors);
+
+        info.inputLabIds = [scored[0].lab.id, scored[1].lab.id];
+    }
+
+    private selectReaction(): void {
+        const info = this.systemInfo;
+        const pairFor = LabManager.reagentsForProduct;
+
+        for (const product of PRODUCT_PRIORITIES) {
+            if (this.getAvailable(product) >= COMPOUND_TARGET_AMOUNT) continue;
+
+            const pair = pairFor(product);
+            if (!pair) continue;
+
+            const [a, b] = pair;
+            if (this.getAvailable(a) >= REAGENT_MIN_AMOUNT && this.getAvailable(b) >= REAGENT_MIN_AMOUNT) {
+                if (info.product !== product) {
+                    Logger.info(`[Labs] ${this.colony.colonyInfo.id}: producing ${product} from ${a} + ${b}`);
+                }
+                info.product = product;
+                info.reagents = [a, b];
+                return;
+            }
+        }
+
+        delete info.product;
+        delete info.reagents;
+    }
+
+    /** Looks up which two reagents react into the given product. */
+    public static reagentsForProduct(product: ResourceConstant): [ResourceConstant, ResourceConstant] | null {
+        for (const a in REACTIONS) {
+            const row = REACTIONS[a];
+            for (const b in row) {
+                if (row[b] === product) {
+                    return [a as ResourceConstant, b as ResourceConstant];
+                }
+            }
+        }
+        return null;
+    }
+
+    private getAvailable(resource: ResourceConstant): number {
+        const room = this.colony.getMainRoom();
+        let amount = 0;
+        if (room.terminal) amount += room.terminal.store[resource] || 0;
+        if (room.storage) amount += room.storage.store[resource] || 0;
+        return amount;
+    }
+
+    private runReactions(labs: StructureLab[]): void {
+        const info = this.systemInfo;
+        if (!info.product || !info.reagents || !info.inputLabIds) return;
+
+        const input1 = Game.getObjectById(info.inputLabIds[0]);
+        const input2 = Game.getObjectById(info.inputLabIds[1]);
+        if (!input1 || !input2) return;
+
+        if ((input1.store[info.reagents[0]] || 0) < LAB_REACTION_AMOUNT) return;
+        if ((input2.store[info.reagents[1]] || 0) < LAB_REACTION_AMOUNT) return;
+
+        for (const lab of labs) {
+            if (lab.id === input1.id || lab.id === input2.id) continue;
+            if (lab.cooldown > 0) continue;
+            if (lab.mineralType && lab.mineralType !== info.product) continue;
+            lab.runReaction(input1, input2);
+        }
+    }
+
+    /**
+     * Finds a lab that can boost the given body part right now (enough compound
+     * and energy for at least `partCount` parts).
+     */
+    public static findBoostLab(room: Room, part: BodyPartConstant, partCount: number): StructureLab | null {
+        if (typeof room.find !== "function") return null;
+        const compounds = BOOSTS_BY_PART[part];
+        if (!compounds) return null;
+
+        const labs = room.find<StructureLab>(FIND_MY_STRUCTURES, {
+            filter: s => s.structureType === STRUCTURE_LAB,
+        });
+
+        for (const compound of compounds) {
+            const lab = labs.find(
+                l =>
+                    l.mineralType === compound &&
+                    l.store[compound as ResourceConstant] >= LAB_BOOST_MINERAL * partCount &&
+                    l.store[RESOURCE_ENERGY] >= LAB_BOOST_ENERGY * partCount,
+            );
+            if (lab) return lab;
+        }
+        return null;
+    }
+}

--- a/src/managers/lab-manager.ts
+++ b/src/managers/lab-manager.ts
@@ -96,6 +96,7 @@ export class LabManager {
     private selectReaction(): void {
         const info = this.systemInfo;
         const pairFor = LabManager.reagentsForProduct;
+        let buyRequests: ResourceConstant[] | undefined;
 
         for (const product of PRODUCT_PRIORITIES) {
             if (this.getAvailable(product) >= COMPOUND_TARGET_AMOUNT) continue;
@@ -104,18 +105,35 @@ export class LabManager {
             if (!pair) continue;
 
             const [a, b] = pair;
-            if (this.getAvailable(a) >= REAGENT_MIN_AMOUNT && this.getAvailable(b) >= REAGENT_MIN_AMOUNT) {
+            const missing = [a, b].filter(r => this.getAvailable(r) < REAGENT_MIN_AMOUNT);
+
+            if (missing.length === 0) {
                 if (info.product !== product) {
                     Logger.info(`[Labs] ${this.colony.colonyInfo.id}: producing ${product} from ${a} + ${b}`);
                 }
                 info.product = product;
                 info.reagents = [a, b];
+                delete info.buyRequests;
                 return;
+            }
+
+            // Remember what blocks the highest-priority product. Only raw
+            // minerals are worth buying — compounds we can make ourselves.
+            if (!buyRequests) {
+                const rawMissing = missing.filter(r => r.length === 1);
+                if (rawMissing.length > 0) {
+                    buyRequests = rawMissing;
+                }
             }
         }
 
         delete info.product;
         delete info.reagents;
+        if (buyRequests) {
+            info.buyRequests = buyRequests;
+        } else {
+            delete info.buyRequests;
+        }
     }
 
     /** Looks up which two reagents react into the given product. */

--- a/src/managers/link-manager.test.ts
+++ b/src/managers/link-manager.test.ts
@@ -1,0 +1,101 @@
+import { expect } from "chai";
+import { LinkManager } from "./link-manager";
+
+describe("LinkManager", () => {
+    beforeEach(() => {
+        (global as any).FIND_SOURCES = "sources";
+        (global as any).FIND_MY_STRUCTURES = "myStructures";
+        (global as any).STRUCTURE_LINK = "link";
+        (global as any).RESOURCE_ENERGY = "energy";
+    });
+
+    const makeLink = (opts: { nearSource?: boolean; nearController?: boolean; energy?: number }): any => ({
+        structureType: "link",
+        cooldown: 0,
+        store: {
+            energy: opts.energy || 0,
+            getFreeCapacity: () => 800 - (opts.energy || 0),
+        },
+        pos: {
+            inRangeTo: (target: any, _range: number) => {
+                if (target.isSource) return opts.nearSource || false;
+                if (target.isController) return opts.nearController || false;
+                return false;
+            },
+        },
+        transferEnergy: () => 0,
+    });
+
+    describe("classifyLinks", () => {
+        it("should classify source, controller, and core links", () => {
+            const sourcePos = { isSource: true };
+            const room: any = {
+                controller: { pos: { isController: true } },
+                find: (type: string) => (type === "sources" ? [{ pos: sourcePos }] : []),
+            };
+
+            const sourceLink = makeLink({ nearSource: true });
+            const controllerLink = makeLink({ nearController: true });
+            const coreLink = makeLink({});
+
+            const result = LinkManager.classifyLinks(room, [sourceLink, controllerLink, coreLink]);
+
+            expect(result.sourceLinks).to.deep.equal([sourceLink]);
+            expect(result.controllerLink).to.equal(controllerLink);
+            expect(result.coreLink).to.equal(coreLink);
+        });
+    });
+
+    describe("run", () => {
+        it("should transfer from a full source link to the controller link", () => {
+            const sourcePos = { isSource: true };
+            const sourceLink = makeLink({ nearSource: true, energy: 800 });
+            const controllerLink = makeLink({ nearController: true, energy: 0 });
+
+            let transferredTo: any = null;
+            sourceLink.transferEnergy = (target: any) => {
+                transferredTo = target;
+                return 0;
+            };
+
+            const room: any = {
+                controller: { pos: { isController: true } },
+                find: (type: string) => {
+                    if (type === "sources") return [{ pos: sourcePos }];
+                    return [sourceLink, controllerLink];
+                },
+            };
+
+            const colony: any = { getMainRoom: () => room };
+            new LinkManager(colony).run();
+
+            expect(transferredTo).to.equal(controllerLink);
+        });
+
+        it("should not transfer when the source link is on cooldown", () => {
+            const sourcePos = { isSource: true };
+            const sourceLink = makeLink({ nearSource: true, energy: 800 });
+            sourceLink.cooldown = 5;
+            const controllerLink = makeLink({ nearController: true });
+
+            let transferred = false;
+            sourceLink.transferEnergy = () => {
+                transferred = true;
+                return 0;
+            };
+
+            const room: any = {
+                controller: { pos: { isController: true } },
+                find: (type: string) => {
+                    if (type === "sources") return [{ pos: sourcePos }];
+                    return [sourceLink, controllerLink];
+                },
+            };
+
+            const colony: any = { getMainRoom: () => room };
+            new LinkManager(colony).run();
+
+            expect(transferred).to.equal(false);
+        });
+    });
+});

--- a/src/managers/link-manager.ts
+++ b/src/managers/link-manager.ts
@@ -1,0 +1,80 @@
+import { ColonyManager } from "../prototypes/types";
+
+/**
+ * Moves energy through the room's link network each tick:
+ * source links -> controller link (to feed upgraders) -> core link (next to storage/spawn).
+ * Without this, links get built but never transfer anything.
+ */
+export class LinkManager {
+    private colony: ColonyManager;
+
+    constructor(colony: ColonyManager) {
+        this.colony = colony;
+    }
+
+    public run(): void {
+        const room = this.colony.getMainRoom();
+        if (!room || !room.controller || typeof room.find !== "function") return;
+
+        const links = room.find<StructureLink>(FIND_MY_STRUCTURES, {
+            filter: s => s.structureType === STRUCTURE_LINK,
+        });
+        if (links.length < 2) return;
+
+        const { sourceLinks, controllerLink, coreLink } = LinkManager.classifyLinks(room, links);
+
+        for (const link of sourceLinks) {
+            if (link.cooldown > 0 || link.store[RESOURCE_ENERGY] < 400) continue;
+
+            const target = LinkManager.pickReceiver(controllerLink, coreLink);
+            if (target) {
+                link.transferEnergy(target);
+            }
+        }
+
+        // Top up the controller link from the core link so upgraders always have energy nearby.
+        if (
+            coreLink &&
+            controllerLink &&
+            coreLink.cooldown === 0 &&
+            coreLink.store[RESOURCE_ENERGY] >= 400 &&
+            controllerLink.store[RESOURCE_ENERGY] < 400
+        ) {
+            coreLink.transferEnergy(controllerLink);
+        }
+    }
+
+    public static classifyLinks(
+        room: Room,
+        links: StructureLink[],
+    ): { sourceLinks: StructureLink[]; controllerLink?: StructureLink; coreLink?: StructureLink } {
+        const sources = room.find(FIND_SOURCES);
+        const sourceLinks: StructureLink[] = [];
+        let controllerLink: StructureLink | undefined;
+        let coreLink: StructureLink | undefined;
+
+        for (const link of links) {
+            if (sources.some(s => link.pos.inRangeTo(s.pos, 2))) {
+                sourceLinks.push(link);
+            } else if (room.controller && link.pos.inRangeTo(room.controller.pos, 3)) {
+                controllerLink = link;
+            } else {
+                // Anything else (near storage/spawn) acts as the core receiver.
+                coreLink = link;
+            }
+        }
+
+        return { sourceLinks, controllerLink, coreLink };
+    }
+
+    private static pickReceiver(controllerLink?: StructureLink, coreLink?: StructureLink): StructureLink | undefined {
+        // Feed the controller link first — upgrader throughput is the main win from links.
+        if (controllerLink && controllerLink.store.getFreeCapacity(RESOURCE_ENERGY) >= 400) {
+            return controllerLink;
+        }
+        if (coreLink && coreLink.store.getFreeCapacity(RESOURCE_ENERGY) >= 400) {
+            return coreLink;
+        }
+        return undefined;
+    }
+}

--- a/src/managers/observer-manager.test.ts
+++ b/src/managers/observer-manager.test.ts
@@ -1,0 +1,55 @@
+import { expect } from "chai";
+import { ObserverManager } from "./observer-manager";
+
+describe("ObserverManager", () => {
+    beforeEach(() => {
+        (global as any).OBSERVER_RANGE = 10;
+        (global as any).Game = {
+            time: 5000,
+            rooms: {},
+            map: {
+                describeExits: () => ({ "1": "W1N2", "3": "W2N1" }),
+                getRoomLinearDistance: (a: string, b: string) => (b === "W9N9" ? 99 : 1),
+            },
+        };
+    });
+
+    const makeColony = (rooms: any): any => ({
+        getMainRoom: () => ({ name: "W1N1" }),
+        colonyInfo: { rooms },
+    });
+
+    describe("pickObserveTarget", () => {
+        it("should pick the stalest room needing a scout", () => {
+            const colony = makeColony({
+                W1N1: { name: "W1N1", isMain: true, lastScouted: 5000 },
+                W1N2: { name: "W1N2", lastScouted: 100 },
+                W2N1: { name: "W2N1", lastScouted: 50 },
+            });
+
+            expect(ObserverManager.pickObserveTarget(colony, "W1N1")).to.equal("W2N1");
+        });
+
+        it("should skip rooms beyond observer range", () => {
+            const colony = makeColony({
+                W1N1: { name: "W1N1", isMain: true, lastScouted: 5000 },
+                W9N9: { name: "W9N9", lastScouted: 10 },
+            });
+            (global as any).Game.map.describeExits = () => ({});
+
+            // W9N9 is stalest but 99 rooms away — unreachable for the observer
+            expect(ObserverManager.pickObserveTarget(colony, "W1N1")).to.equal(undefined);
+        });
+
+        it("should return undefined when everything is fresh", () => {
+            const colony = makeColony({
+                W1N1: { name: "W1N1", isMain: true, lastScouted: 5000 },
+                W1N2: { name: "W1N2", lastScouted: 4999 },
+                W2N1: { name: "W2N1", lastScouted: 4999 },
+            });
+            (global as any).Game.rooms = { W1N2: {}, W2N1: {} };
+
+            expect(ObserverManager.pickObserveTarget(colony, "W1N1")).to.equal(undefined);
+        });
+    });
+});

--- a/src/managers/observer-manager.ts
+++ b/src/managers/observer-manager.ts
@@ -1,0 +1,59 @@
+import { ColonyManager } from "../prototypes/types";
+import { RoomUtils } from "../utils/room-utils";
+
+/**
+ * Uses the RCL 8 observer to keep intel fresh without scout creeps:
+ * each tick it ingests the room observed last tick, then requests the
+ * next stalest room in range.
+ */
+export class ObserverManager {
+    private colony: ColonyManager;
+
+    constructor(colony: ColonyManager) {
+        this.colony = colony;
+    }
+
+    public run(): void {
+        const room = this.colony.getMainRoom();
+        if (!room || !room.controller || (room.controller.level || 0) < 8) return;
+        if (typeof room.find !== "function") return;
+
+        const observer = room.find<StructureObserver>(FIND_MY_STRUCTURES, {
+            filter: s => s.structureType === STRUCTURE_OBSERVER,
+        })[0];
+        if (!observer) return;
+
+        if (!this.colony.colonyInfo.observerManagement) {
+            this.colony.colonyInfo.observerManagement = {};
+        }
+        const info = this.colony.colonyInfo.observerManagement;
+
+        // Vision from observeRoom only lasts the following tick — ingest it now.
+        if (info.pendingRoom) {
+            const observed = Game.rooms[info.pendingRoom];
+            if (observed) {
+                RoomUtils.updateRoomData(this.colony, observed);
+            }
+            delete info.pendingRoom;
+        }
+
+        const target = ObserverManager.pickObserveTarget(this.colony, room.name);
+        if (target && observer.observeRoom(target) === OK) {
+            info.pendingRoom = target;
+        }
+    }
+
+    /** The stalest room needing a scout that the observer can actually reach. */
+    public static pickObserveTarget(colony: ColonyManager, fromRoom: string): string | undefined {
+        const candidates = RoomUtils.getRoomsNeedingScout(colony).filter(
+            roomName => roomName !== fromRoom && Game.map.getRoomLinearDistance(fromRoom, roomName) <= OBSERVER_RANGE,
+        );
+        if (candidates.length === 0) return undefined;
+
+        return candidates.sort((a, b) => {
+            const dataA = colony.colonyInfo.rooms[a];
+            const dataB = colony.colonyInfo.rooms[b];
+            return (dataA?.lastScouted || 0) - (dataB?.lastScouted || 0);
+        })[0];
+    }
+}

--- a/src/managers/terminal-manager.ts
+++ b/src/managers/terminal-manager.ts
@@ -9,6 +9,12 @@ export const MINERAL_SELL_THRESHOLD = 3000;
 export const MINERAL_KEEP_AMOUNT = 1000;
 /** Max amount to sell in one deal. */
 const MAX_DEAL_AMOUNT = 5000;
+/** Energy sent per support shipment to a struggling colony. */
+const ENERGY_SUPPORT_AMOUNT = 10000;
+/** Only send support when our own stored-energy ratio is above this. */
+const ENERGY_SUPPORT_MIN_OWN_PERCENT = 0.7;
+/** Colonies below this stored-energy ratio receive support. */
+const ENERGY_SUPPORT_NEEDY_PERCENT = 0.3;
 
 /**
  * Turns surplus minerals into credits via the market. Runs infrequently —
@@ -28,12 +34,46 @@ export class TerminalManager {
         const terminal = room?.terminal;
         if (!terminal || !terminal.isActive() || terminal.cooldown > 0) return;
 
+        // Helping a sister colony beats selling — one action per cooldown window.
+        if (this.sendEnergySupport(terminal)) return;
+
         this.sellSurplusMinerals(terminal);
+    }
+
+    /** Ships energy to another of our colonies whose storage is running dry. */
+    private sendEnergySupport(terminal: StructureTerminal): boolean {
+        const ownPercent = this.colony.colonyInfo.energyManagement?.storedEnergyPercent || 0;
+        if (ownPercent < ENERGY_SUPPORT_MIN_OWN_PERCENT) return false;
+        if (terminal.store[RESOURCE_ENERGY] < ENERGY_SUPPORT_AMOUNT + TERMINAL_ENERGY_RESERVE) return false;
+
+        for (const colonyId in Memory.colonies) {
+            if (colonyId === this.colony.colonyInfo.id) continue;
+
+            const other = Memory.colonies[colonyId];
+            if (!other) continue;
+
+            const otherRoom = Game.rooms[colonyId];
+            if (!otherRoom?.terminal || otherRoom.terminal.store.getFreeCapacity() < ENERGY_SUPPORT_AMOUNT) continue;
+
+            const otherPercent = other.energyManagement?.storedEnergyPercent;
+            if (typeof otherPercent !== "number" || otherPercent >= ENERGY_SUPPORT_NEEDY_PERCENT) continue;
+
+            const result = terminal.send(RESOURCE_ENERGY, ENERGY_SUPPORT_AMOUNT, colonyId);
+            if (result === OK) {
+                Logger.info(
+                    `[Terminal] ${terminal.room.name} sent ${ENERGY_SUPPORT_AMOUNT} energy to struggling colony ${colonyId}`,
+                );
+                return true;
+            }
+        }
+        return false;
     }
 
     private sellSurplusMinerals(terminal: StructureTerminal): void {
         for (const resourceType in terminal.store) {
             if (resourceType === RESOURCE_ENERGY) continue;
+            // Only sell raw minerals (single-letter resources); compounds are kept for boosting.
+            if (resourceType.length > 1) continue;
 
             const amount = terminal.store[resourceType as ResourceConstant];
             if (amount <= MINERAL_SELL_THRESHOLD) continue;

--- a/src/managers/terminal-manager.ts
+++ b/src/managers/terminal-manager.ts
@@ -1,0 +1,75 @@
+import { ColonyManager } from "../prototypes/types";
+import { Logger } from "../utils/logger";
+
+/** Energy the terminal keeps on hand to pay market transaction fees. */
+export const TERMINAL_ENERGY_RESERVE = 10000;
+/** Start selling a mineral once the terminal holds more than this. */
+export const MINERAL_SELL_THRESHOLD = 3000;
+/** Keep this much of each mineral for future lab use. */
+export const MINERAL_KEEP_AMOUNT = 1000;
+/** Max amount to sell in one deal. */
+const MAX_DEAL_AMOUNT = 5000;
+
+/**
+ * Turns surplus minerals into credits via the market. Runs infrequently —
+ * market order scans are CPU-heavy.
+ */
+export class TerminalManager {
+    private colony: ColonyManager;
+
+    constructor(colony: ColonyManager) {
+        this.colony = colony;
+    }
+
+    public run(): void {
+        if (Game.time % 100 !== 0) return;
+
+        const room = this.colony.getMainRoom();
+        const terminal = room?.terminal;
+        if (!terminal || !terminal.isActive() || terminal.cooldown > 0) return;
+
+        this.sellSurplusMinerals(terminal);
+    }
+
+    private sellSurplusMinerals(terminal: StructureTerminal): void {
+        for (const resourceType in terminal.store) {
+            if (resourceType === RESOURCE_ENERGY) continue;
+
+            const amount = terminal.store[resourceType as ResourceConstant];
+            if (amount <= MINERAL_SELL_THRESHOLD) continue;
+
+            const sellAmount = Math.min(amount - MINERAL_KEEP_AMOUNT, MAX_DEAL_AMOUNT);
+            if (this.sellToBestOrder(terminal, resourceType as ResourceConstant, sellAmount)) {
+                return; // One deal per terminal cooldown window
+            }
+        }
+    }
+
+    private sellToBestOrder(terminal: StructureTerminal, resourceType: ResourceConstant, amount: number): boolean {
+        const orders = Game.market
+            .getAllOrders({ type: ORDER_BUY, resourceType })
+            .filter(o => o.amount > 0 && o.roomName)
+            .sort((a, b) => b.price - a.price);
+
+        for (const order of orders) {
+            const dealAmount = Math.min(amount, order.amount);
+            const energyCost = Game.market.calcTransactionCost(
+                dealAmount,
+                terminal.room.name,
+                order.roomName as string,
+            );
+
+            if (energyCost > terminal.store[RESOURCE_ENERGY]) continue;
+
+            const result = Game.market.deal(order.id, dealAmount, terminal.room.name);
+            if (result === OK) {
+                Logger.info(
+                    `[Terminal] ${terminal.room.name} sold ${dealAmount} ${resourceType} at ${order.price} cr (fee: ${energyCost} energy)`,
+                );
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/managers/terminal-manager.ts
+++ b/src/managers/terminal-manager.ts
@@ -15,6 +15,16 @@ const ENERGY_SUPPORT_AMOUNT = 10000;
 const ENERGY_SUPPORT_MIN_OWN_PERCENT = 0.7;
 /** Colonies below this stored-energy ratio receive support. */
 const ENERGY_SUPPORT_NEEDY_PERCENT = 0.3;
+/** Amount of a reagent bought per market deal. */
+const REAGENT_BUY_AMOUNT = 1000;
+/** Stop buying once we hold this much of the reagent. */
+const REAGENT_BUY_TARGET = 2000;
+/** Credits kept in reserve — never spend below this. */
+const CREDIT_RESERVE = 1000;
+/** Without price history, refuse to pay more than this per unit. */
+const FALLBACK_MAX_PRICE = 10;
+/** Pay at most this multiple of the recent average price. */
+const MAX_PRICE_MULTIPLIER = 1.5;
 
 /**
  * Turns surplus minerals into credits via the market. Runs infrequently —
@@ -34,10 +44,58 @@ export class TerminalManager {
         const terminal = room?.terminal;
         if (!terminal || !terminal.isActive() || terminal.cooldown > 0) return;
 
-        // Helping a sister colony beats selling — one action per cooldown window.
+        // One terminal action per cooldown window, in priority order:
+        // support a sister colony > unblock the lab pipeline > sell surplus.
         if (this.sendEnergySupport(terminal)) return;
+        if (this.buyMissingReagents(terminal)) return;
 
         this.sellSurplusMinerals(terminal);
+    }
+
+    /** Buys raw minerals the LabManager needs but the colony can't mine locally. */
+    private buyMissingReagents(terminal: StructureTerminal): boolean {
+        const requests = this.colony.colonyInfo.labManagement?.buyRequests;
+        if (!requests || requests.length === 0) return false;
+
+        for (const resource of requests) {
+            const room = terminal.room;
+            const onHand = (terminal.store[resource] || 0) + (room.storage?.store[resource] || 0);
+            if (onHand >= REAGENT_BUY_TARGET) continue;
+
+            const maxPrice = this.getMaxBuyPrice(resource);
+            const orders = Game.market
+                .getAllOrders({ type: ORDER_SELL, resourceType: resource })
+                .filter(o => o.amount > 0 && o.roomName && o.price <= maxPrice)
+                .sort((a, b) => a.price - b.price);
+
+            for (const order of orders) {
+                const amount = Math.min(REAGENT_BUY_AMOUNT, order.amount, REAGENT_BUY_TARGET - onHand);
+                const creditCost = amount * order.price;
+                if (Game.market.credits - creditCost < CREDIT_RESERVE) break;
+
+                const energyCost = Game.market.calcTransactionCost(amount, room.name, order.roomName as string);
+                if (energyCost > terminal.store[RESOURCE_ENERGY]) continue;
+
+                const result = Game.market.deal(order.id, amount, room.name);
+                if (result === OK) {
+                    Logger.info(
+                        `[Terminal] ${room.name} bought ${amount} ${resource} at ${order.price} cr for the labs`,
+                    );
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private getMaxBuyPrice(resource: ResourceConstant): number {
+        const history = Game.market.getHistory(resource);
+        if (!history || history.length === 0) return FALLBACK_MAX_PRICE;
+
+        const recent = history[history.length - 1];
+        if (!recent || !recent.avgPrice) return FALLBACK_MAX_PRICE;
+
+        return recent.avgPrice * MAX_PRICE_MULTIPLIER;
     }
 
     /** Ships energy to another of our colonies whose storage is running dry. */
@@ -70,10 +128,15 @@ export class TerminalManager {
     }
 
     private sellSurplusMinerals(terminal: StructureTerminal): void {
+        const labInfo = this.colony.colonyInfo.labManagement;
+        const labNeeds = new Set<string>([...(labInfo?.reagents || []), ...(labInfo?.buyRequests || [])]);
+
         for (const resourceType in terminal.store) {
             if (resourceType === RESOURCE_ENERGY) continue;
             // Only sell raw minerals (single-letter resources); compounds are kept for boosting.
             if (resourceType.length > 1) continue;
+            // Don't sell what the lab pipeline is consuming or trying to acquire.
+            if (labNeeds.has(resourceType)) continue;
 
             const amount = terminal.store[resourceType as ResourceConstant];
             if (amount <= MINERAL_SELL_THRESHOLD) continue;

--- a/src/prototypes/colony.extensions.ts
+++ b/src/prototypes/colony.extensions.ts
@@ -17,6 +17,12 @@ interface Colony {
     goapManagement?: ColonyGoapManagement;
     expansionManagement?: ColonyExpansionManagement;
     labManagement?: ColonyLabManagement;
+    observerManagement?: ColonyObserverManagement;
+}
+
+interface ColonyObserverManagement {
+    /** Room requested via observeRoom last tick; vision arrives the tick after. */
+    pendingRoom?: string;
 }
 
 interface BaseSystemInfo {
@@ -72,6 +78,8 @@ interface ColonyLabManagement extends BaseSystemInfo {
     reagents?: ResourceConstant[];
     /** The compound currently being produced. */
     product?: ResourceConstant;
+    /** Raw minerals the terminal should buy to unblock the next wanted reaction. */
+    buyRequests?: ResourceConstant[];
 }
 
 interface EnergyUsageTracking {

--- a/src/prototypes/colony.extensions.ts
+++ b/src/prototypes/colony.extensions.ts
@@ -16,6 +16,7 @@ interface Colony {
     infrastructureManagement?: ColonyInfrastructureManagement;
     goapManagement?: ColonyGoapManagement;
     expansionManagement?: ColonyExpansionManagement;
+    labManagement?: ColonyLabManagement;
 }
 
 interface BaseSystemInfo {
@@ -23,7 +24,12 @@ interface BaseSystemInfo {
     energyUsageTracking?: EnergyUsageTracking;
 }
 
-interface ColonyDefenseManagement extends BaseSystemInfo {}
+interface ColonyDefenseManagement extends BaseSystemInfo {
+    /** Min-cut rampart perimeter positions for the main room. */
+    perimeter?: { x: number; y: number }[];
+    /** RCL at which the perimeter was last computed (recompute as the base grows). */
+    lastPerimeterRcl?: number;
+}
 
 interface ColonyBuilderManagement extends BaseSystemInfo {
     buildQueue: Id<ConstructionSite>[];
@@ -57,6 +63,15 @@ interface ColonyExpansionManagement extends BaseSystemInfo {
     expansionTarget?: string;
     /** Tick the current expansion attempt started (for stall detection). */
     expansionStartTime?: number;
+}
+
+interface ColonyLabManagement extends BaseSystemInfo {
+    /** The two labs that hold reagents for the active reaction. */
+    inputLabIds?: Id<StructureLab>[];
+    /** The reagents loaded into the input labs (same order as inputLabIds). */
+    reagents?: ResourceConstant[];
+    /** The compound currently being produced. */
+    product?: ResourceConstant;
 }
 
 interface EnergyUsageTracking {

--- a/src/prototypes/colony.extensions.ts
+++ b/src/prototypes/colony.extensions.ts
@@ -15,6 +15,7 @@ interface Colony {
     defenseManagement?: ColonyDefenseManagement;
     infrastructureManagement?: ColonyInfrastructureManagement;
     goapManagement?: ColonyGoapManagement;
+    expansionManagement?: ColonyExpansionManagement;
 }
 
 interface BaseSystemInfo {
@@ -49,6 +50,13 @@ interface ColonyInfrastructureManagement extends BaseSystemInfo {
 interface ColonyGoapManagement extends BaseSystemInfo {
     activeGoalName?: string;
     planActionNames?: string[];
+}
+
+interface ColonyExpansionManagement extends BaseSystemInfo {
+    /** Room name this colony is currently expanding into. */
+    expansionTarget?: string;
+    /** Tick the current expansion attempt started (for stall detection). */
+    expansionStartTime?: number;
 }
 
 interface EnergyUsageTracking {

--- a/src/prototypes/colony.ts
+++ b/src/prototypes/colony.ts
@@ -1,10 +1,13 @@
 import { ConstructionManager } from "../managers/construction-manager";
+import { LinkManager } from "../managers/link-manager";
 import { RoadManager } from "../managers/road-manager";
+import { TerminalManager } from "../managers/terminal-manager";
 
 import { BaseSystem, ColonyCreeps, ColonyManager, CreepRole, CreepStatus, Systems } from "./types";
 import { BuilderSystem } from "./../systems/builder-system";
 import { DefenseSystem } from "./../systems/defense-system";
 import { EnergySystem } from "./../systems/energy-system";
+import { ExpansionSystem } from "../systems/expansion-system";
 import { InfrastructureSystem } from "../systems/infrastructure-system";
 import { Movement } from "infrastructure/movement";
 import { Spawning } from "infrastructure/spawning";
@@ -18,6 +21,7 @@ function getSystems(colony: ColonyManager): Systems {
         infrastructure: new InfrastructureSystem(colony),
         upgrade: new UpgradeSystem(colony),
         builder: new BuilderSystem(colony),
+        expansion: new ExpansionSystem(colony),
     };
 }
 
@@ -26,11 +30,15 @@ export class ColonyManagerImpl implements ColonyManager {
     public systems = getSystems(this);
     public constructionManager: ConstructionManager;
     public roadManager: RoadManager;
+    public linkManager: LinkManager;
+    public terminalManager: TerminalManager;
 
     public constructor(colony: Colony) {
         this.colonyInfo = colony;
         this.constructionManager = new ConstructionManager(this);
         this.roadManager = new RoadManager(this);
+        this.linkManager = new LinkManager(this);
+        this.terminalManager = new TerminalManager(this);
     }
 
     public get energyManagement(): ColonyEnergyManagement | undefined {
@@ -89,6 +97,8 @@ export class ColonyManagerImpl implements ColonyManager {
         spawnManager.run();
         systems.forEach(x => x.run());
         this.constructionManager.run();
+        this.linkManager.run();
+        this.terminalManager.run();
 
         this.creepManager();
         this.visualizeStats();

--- a/src/prototypes/colony.ts
+++ b/src/prototypes/colony.ts
@@ -1,6 +1,7 @@
 import { ConstructionManager } from "../managers/construction-manager";
 import { LabManager } from "../managers/lab-manager";
 import { LinkManager } from "../managers/link-manager";
+import { ObserverManager } from "../managers/observer-manager";
 import { RoadManager } from "../managers/road-manager";
 import { TerminalManager } from "../managers/terminal-manager";
 
@@ -34,6 +35,7 @@ export class ColonyManagerImpl implements ColonyManager {
     public linkManager: LinkManager;
     public terminalManager: TerminalManager;
     public labManager: LabManager;
+    public observerManager: ObserverManager;
 
     public constructor(colony: Colony) {
         this.colonyInfo = colony;
@@ -42,6 +44,7 @@ export class ColonyManagerImpl implements ColonyManager {
         this.linkManager = new LinkManager(this);
         this.terminalManager = new TerminalManager(this);
         this.labManager = new LabManager(this);
+        this.observerManager = new ObserverManager(this);
     }
 
     public get energyManagement(): ColonyEnergyManagement | undefined {
@@ -103,6 +106,7 @@ export class ColonyManagerImpl implements ColonyManager {
         this.linkManager.run();
         this.terminalManager.run();
         this.labManager.run();
+        this.observerManager.run();
 
         this.creepManager();
         this.visualizeStats();

--- a/src/prototypes/colony.ts
+++ b/src/prototypes/colony.ts
@@ -1,4 +1,5 @@
 import { ConstructionManager } from "../managers/construction-manager";
+import { LabManager } from "../managers/lab-manager";
 import { LinkManager } from "../managers/link-manager";
 import { RoadManager } from "../managers/road-manager";
 import { TerminalManager } from "../managers/terminal-manager";
@@ -32,6 +33,7 @@ export class ColonyManagerImpl implements ColonyManager {
     public roadManager: RoadManager;
     public linkManager: LinkManager;
     public terminalManager: TerminalManager;
+    public labManager: LabManager;
 
     public constructor(colony: Colony) {
         this.colonyInfo = colony;
@@ -39,6 +41,7 @@ export class ColonyManagerImpl implements ColonyManager {
         this.roadManager = new RoadManager(this);
         this.linkManager = new LinkManager(this);
         this.terminalManager = new TerminalManager(this);
+        this.labManager = new LabManager(this);
     }
 
     public get energyManagement(): ColonyEnergyManagement | undefined {
@@ -99,6 +102,7 @@ export class ColonyManagerImpl implements ColonyManager {
         this.constructionManager.run();
         this.linkManager.run();
         this.terminalManager.run();
+        this.labManager.run();
 
         this.creepManager();
         this.visualizeStats();

--- a/src/prototypes/creep.extensions.ts
+++ b/src/prototypes/creep.extensions.ts
@@ -5,10 +5,20 @@ declare global {
         name: string;
         colonyId: string;
         movementSystem?: CreepMovementSystem;
-        targetId?: Id<Tombstone | StructureExtension | AnyStructure | Resource<ResourceConstant> | Source | ConstructionSite<BuildableStructureConstant> | _HasId>;
+        targetId?: Id<
+            | Tombstone
+            | StructureExtension
+            | AnyStructure
+            | Resource<ResourceConstant>
+            | Source
+            | ConstructionSite<BuildableStructureConstant>
+            | _HasId
+        >;
         targetPos?: RoomPosition;
         working: boolean;
         workDuration: number;
+        /** Set once a combat creep has tried to boost (whether or not a lab was available). */
+        boostAttempted?: boolean;
     }
 
     type TargetType = (_HasId & _HasRoomPosition) | null;

--- a/src/prototypes/creep.ts
+++ b/src/prototypes/creep.ts
@@ -353,6 +353,45 @@ export abstract class CreepRunner {
     }
 
     /**
+     * Finds an own rampart the creep can stand on to fight the target from safety:
+     * walkable (no blocking structure), unoccupied (or occupied by this creep), and
+     * within `range` of the target. Melee wants range 1, ranged wants range 3.
+     */
+    protected findCombatRampart(target: _HasRoomPosition, range: number): StructureRampart | null {
+        const { creep } = this;
+        if (typeof creep.room.find !== "function") return null;
+
+        const ramparts = creep.room.find<StructureRampart>(FIND_MY_STRUCTURES, {
+            filter: s => s.structureType === STRUCTURE_RAMPART && s.pos.inRangeTo(target.pos, range),
+        });
+
+        const usable = ramparts.filter(rampart => {
+            const blocked = rampart.pos
+                .lookFor(LOOK_STRUCTURES)
+                .some(
+                    s =>
+                        s.structureType !== STRUCTURE_RAMPART &&
+                        s.structureType !== STRUCTURE_ROAD &&
+                        s.structureType !== STRUCTURE_CONTAINER,
+                );
+            if (blocked) return false;
+
+            const occupants = rampart.pos.lookFor(LOOK_CREEPS);
+            return occupants.length === 0 || occupants[0].id === creep.id;
+        });
+
+        if (usable.length === 0) return null;
+        return creep.pos.findClosestByRange(usable);
+    }
+
+    /** Whether the creep is currently standing on one of our ramparts. */
+    protected isOnOwnRampart(): boolean {
+        return this.creep.pos
+            .lookFor(LOOK_STRUCTURES)
+            .some(s => s.structureType === STRUCTURE_RAMPART && (s as StructureRampart).my);
+    }
+
+    /**
      * One-shot boost attempt for combat creeps: if a lab holds a suitable compound,
      * walk there and boost. Returns true while the creep is busy boosting (the
      * caller should skip its normal behavior for the tick).

--- a/src/prototypes/creep.ts
+++ b/src/prototypes/creep.ts
@@ -1,5 +1,6 @@
 import { Movement } from "infrastructure/movement";
 import { ColonyManager, CreepProfiles, CreepRole, CreepStatus } from "./types";
+import { LabManager } from "managers/lab-manager";
 import { RepairUtils } from "utils/repair-utils";
 import { REPAIR_THRESHOLD_DECAY_PREVENTION, REPAIR_THRESHOLD_EMERGENCY } from "constants/repair-constants";
 import { RoomUtils } from "utils/room-utils";
@@ -349,6 +350,37 @@ export abstract class CreepRunner {
 
     protected findClosestHostile() {
         return this.creep.pos.findClosestByRange(FIND_HOSTILE_CREEPS);
+    }
+
+    /**
+     * One-shot boost attempt for combat creeps: if a lab holds a suitable compound,
+     * walk there and boost. Returns true while the creep is busy boosting (the
+     * caller should skip its normal behavior for the tick).
+     */
+    protected tryBoost(part: BodyPartConstant): boolean {
+        const { creep, memory } = this;
+        if (memory.boostAttempted) return false;
+
+        const unboostedParts = creep.body.filter(p => p.type === part && !p.boost).length;
+        if (unboostedParts === 0) {
+            memory.boostAttempted = true;
+            return false;
+        }
+
+        const lab = LabManager.findBoostLab(creep.room, part, unboostedParts);
+        if (!lab) {
+            memory.boostAttempted = true;
+            return false;
+        }
+
+        const result = lab.boostCreep(creep);
+        if (result === ERR_NOT_IN_RANGE) {
+            this.moveToWithReservation(lab, 5, 1);
+            return true;
+        }
+
+        memory.boostAttempted = true;
+        return false;
     }
 
     public getEnergy(): void {

--- a/src/prototypes/creep.ts
+++ b/src/prototypes/creep.ts
@@ -256,15 +256,20 @@ export abstract class CreepRunner {
         });
     }
 
-    /** Find closest energy stored in container or storage. This includes if you are using containers with a miner creep. */
+    /** Find closest energy stored in container, storage, or a receiving link (links near sources are excluded — they feed the network). */
     protected findClosestStoredEnergy(minEnergy: number) {
         return this.creep.pos.findClosestByRange(FIND_STRUCTURES, {
             filter: structure => {
-                return (
-                    (structure.structureType === STRUCTURE_CONTAINER ||
-                        structure.structureType === STRUCTURE_STORAGE) &&
-                    structure.store[RESOURCE_ENERGY] >= minEnergy
-                );
+                if (structure.structureType === STRUCTURE_CONTAINER || structure.structureType === STRUCTURE_STORAGE) {
+                    return structure.store[RESOURCE_ENERGY] >= minEnergy;
+                }
+                if (structure.structureType === STRUCTURE_LINK && (structure as StructureLink).my) {
+                    return (
+                        structure.store[RESOURCE_ENERGY] >= minEnergy &&
+                        structure.pos.findInRange(FIND_SOURCES, 2).length === 0
+                    );
+                }
+                return false;
             },
         });
     }

--- a/src/prototypes/room.ts
+++ b/src/prototypes/room.ts
@@ -18,14 +18,22 @@ export class RoomExtras {
 
         // 1. Emergency Safe Mode
         if (threat.isSpawnUnderAttack && this.room.controller && this.room.controller.my) {
+            const spawn = this.room.find(FIND_MY_SPAWNS)[0];
             const defenders = this.room.find(FIND_MY_CREEPS, { filter: c => c.memory.role === CreepRole.DEFENDER });
-            if (defenders.length === 0) {
+            const towersWithEnergy = towers.filter(t => t.store[RESOURCE_ENERGY] >= TOWER_ENERGY_COST);
+            const spawnCritical = spawn && spawn.hits < spawn.hitsMax * 0.5;
+
+            // Activate when the spawn is badly damaged, or when we have no way to fight back at all.
+            if (spawnCritical || (defenders.length === 0 && towersWithEnergy.length === 0)) {
                 this.room.controller.activateSafeMode();
             }
         }
 
         // 2. Tower Logic
         if (threat.totalHostiles > 0) {
+            // Focus fire: all towers shoot the same target so damage can outpace healing.
+            const focusTarget = ThreatAssessment.selectTowerTarget(towers, threat);
+
             for (const tower of towers) {
                 // Priority 1: Repair Rampart under attack with a creep inside
                 const rampartUnderAttack = this.findRampartUnderAttack(tower);
@@ -34,15 +42,23 @@ export class RoomExtras {
                     continue;
                 }
 
-                // Priority 2: Heal a creep taking damage OR Attack weakest enemy
-                const creepToHeal = this.findCreepToHeal();
-                if (creepToHeal) {
-                    tower.heal(creepToHeal);
+                if (focusTarget) {
+                    tower.attack(focusTarget);
                     continue;
                 }
 
-                if (threat.weakestHostile) {
-                    tower.attack(threat.weakestHostile);
+                // No killable target (heal-tanks out-heal us). Only waste energy on hostiles
+                // that are actively threatening structures at close range.
+                const closeHostile = tower.pos.findInRange(FIND_HOSTILE_CREEPS, TOWER_OPTIMAL_RANGE)[0];
+                if (closeHostile) {
+                    tower.attack(closeHostile);
+                    continue;
+                }
+
+                // Priority 2: Heal a creep taking damage
+                const creepToHeal = this.findCreepToHeal();
+                if (creepToHeal) {
+                    tower.heal(creepToHeal);
                     continue;
                 }
 

--- a/src/prototypes/spawn.ts
+++ b/src/prototypes/spawn.ts
@@ -15,6 +15,18 @@ export class SpawnExtras {
 
     /** Creates a colony for the room. */
     private initialRoomSetup(): void {
+        const existing = Memory.colonies[this.spawn.room.name];
+        if (existing) {
+            // A colony already exists for this room (e.g. this is a second spawn,
+            // or the main spawn was rebuilt). Attach instead of wiping its memory.
+            this.spawn.memory.colonyId = existing.id;
+            if (!Game.getObjectById(existing.mainSpawnId)) {
+                Logger.info(`Colony ${existing.id}: adopting spawn ${this.spawn.name} as new main spawn`);
+                existing.mainSpawnId = this.spawn.id;
+            }
+            return;
+        }
+
         Logger.info(`Creating initial colony in room: ${this.spawn.room.name}`);
         const colony: Colony = {
             id: this.spawn.room.name,

--- a/src/prototypes/types.ts
+++ b/src/prototypes/types.ts
@@ -43,6 +43,8 @@ export enum CreepRole {
     MINERAL_MINER = "mineral_miner",
     CLAIMER = "claimer",
     PIONEER = "pioneer",
+    RANGED_DEFENDER = "ranged_defender",
+    LAB_HAULER = "lab_hauler",
 }
 
 export interface CreepProfiles {

--- a/src/prototypes/types.ts
+++ b/src/prototypes/types.ts
@@ -40,6 +40,9 @@ export enum CreepRole {
     SCOUT = "scout",
     RESERVER = "reserver",
     EXTENSION_FILLER = "extension_filler",
+    MINERAL_MINER = "mineral_miner",
+    CLAIMER = "claimer",
+    PIONEER = "pioneer",
 }
 
 export interface CreepProfiles {
@@ -85,6 +88,7 @@ export interface Systems {
     infrastructure: any;
     upgrade: any;
     builder: any;
+    expansion: any;
 }
 
 export interface ColonyManager {

--- a/src/systems/defense-system.ts
+++ b/src/systems/defense-system.ts
@@ -3,6 +3,7 @@ import { CreepRole } from "prototypes/types";
 import { CreepSpawner } from "prototypes/CreepSpawner";
 import { DefenderCreepSpawner } from "creep-roles/defender-creep";
 import { HealerCreepSpawner } from "creep-roles/healer-creep";
+import { RangedDefenderCreepSpawner } from "creep-roles/ranged-defender-creep";
 import { RoomUtils } from "utils/room-utils";
 
 export class DefenseSystem extends BaseSystemImpl {
@@ -57,11 +58,11 @@ export class DefenseSystem extends BaseSystemImpl {
     }
 
     public override getCreepSpawners(): CreepSpawner[] {
-        return [new DefenderCreepSpawner(), new HealerCreepSpawner()];
+        return [new DefenderCreepSpawner(), new RangedDefenderCreepSpawner(), new HealerCreepSpawner()];
     }
 
     public override getRolesToTrackEnergy(): CreepRole[] {
-        return [CreepRole.DEFENDER, CreepRole.HEALER];
+        return [CreepRole.DEFENDER, CreepRole.RANGED_DEFENDER, CreepRole.HEALER];
     }
 
     public override getStatus(): string | null {

--- a/src/systems/energy-system.ts
+++ b/src/systems/energy-system.ts
@@ -7,6 +7,7 @@ import { CarrierCreepSpawner } from "creep-roles/carrier-creep";
 import { ExtensionFillerCreepSpawner } from "creep-roles/extension-filler-creep";
 import { ReserverCreepSpawner } from "creep-roles/reserver-creep";
 import { ScoutCreepSpawner } from "creep-roles/scout-creep";
+import { MineralMinerCreepSpawner } from "creep-roles/mineral-miner-creep";
 
 import { Action, Goal, WorldState } from "goap/types";
 import { EnergyCalculator } from "utils/energy-calculator";
@@ -265,6 +266,7 @@ export class EnergySystem extends BaseSystemImpl {
                 new CarrierCreepSpawner(),
                 new ExtensionFillerCreepSpawner(),
                 new ReserverCreepSpawner(),
+                new MineralMinerCreepSpawner(),
             );
         } else {
             spawners.push(new HarvesterCreepSpawner());

--- a/src/systems/expansion-system.ts
+++ b/src/systems/expansion-system.ts
@@ -1,0 +1,209 @@
+import { BaseSystemImpl } from "./base-system";
+import { CreepRole } from "prototypes/types";
+import { CreepSpawner } from "prototypes/CreepSpawner";
+import { ClaimerCreepSpawner } from "creep-roles/claimer-creep";
+import { PioneerCreepSpawner } from "creep-roles/pioneer-creep";
+import { ConstructionUtils } from "utils/construction-utils";
+import { Logger } from "utils/logger";
+
+/** Minimum RCL before a colony considers founding a new one. */
+const MIN_EXPANSION_RCL = 4;
+/** Don't expand into rooms further than this (approximate travel ticks). */
+const MAX_EXPANSION_DISTANCE = 200;
+
+/**
+ * Founds new colonies: picks the best scouted room, claims it, places the
+ * first spawn, and sends pioneers to build it. Once the spawn is finished,
+ * SpawnExtras automatically registers the room as a new colony.
+ */
+export class ExpansionSystem extends BaseSystemImpl {
+    public override get systemInfo(): ColonyExpansionManagement {
+        if (!this.colony.colonyInfo.expansionManagement) {
+            this.colony.colonyInfo.expansionManagement = {
+                nextUpdate: Game.time,
+            };
+        }
+        return this.colony.colonyInfo.expansionManagement;
+    }
+
+    public override get energyUsageTracking(): EnergyUsageTracking {
+        if (!this.systemInfo.energyUsageTracking) {
+            this.systemInfo.energyUsageTracking = {
+                actualEnergyUsagePercentage: 0,
+                estimatedEnergyWorkRate: 0,
+                requestedEnergyUsageWeight: 0,
+                allowedEnergyWorkRate: 0,
+            };
+        }
+        return this.systemInfo.energyUsageTracking;
+    }
+
+    public override onStart(): void {}
+
+    public constructor(colony: any) {
+        super(colony);
+    }
+
+    public override run(): void {
+        super.run();
+
+        if (Game.time % 50 !== 0) return;
+
+        const target = this.systemInfo.expansionTarget;
+        if (target) {
+            this.manageExpansion(target);
+        } else {
+            this.considerExpansion();
+        }
+
+        this.energyUsageTracking.requestedEnergyUsageWeight = this.systemInfo.expansionTarget ? 0.5 : 0;
+    }
+
+    private considerExpansion(): void {
+        // GCL must allow another room
+        const ownedColonies = Object.keys(Memory.colonies).length;
+        if (Game.gcl.level <= ownedColonies) return;
+
+        const room = this.colony.getMainRoom();
+        if (!room || !room.controller || room.controller.level < MIN_EXPANSION_RCL) return;
+
+        // Need enough capacity for a claimer and a healthy economy before expanding
+        if (room.energyCapacityAvailable < 650) return;
+        const energyInfo = this.colony.colonyInfo.energyManagement;
+        if (!energyInfo || energyInfo.storedEnergyPercent < 0.4) return;
+
+        const candidate = this.findBestExpansionCandidate();
+        if (candidate) {
+            Logger.info(`[Expansion] Colony ${this.colony.colonyInfo.id} expanding to ${candidate}`);
+            this.systemInfo.expansionTarget = candidate;
+            this.systemInfo.expansionStartTime = Game.time;
+        }
+    }
+
+    private findBestExpansionCandidate(): string | undefined {
+        const rooms = this.colony.colonyInfo.rooms;
+        const candidates: { name: string; sourceCount: number; distance: number }[] = [];
+        const myUsername = this.colony.getMainSpawn()?.owner?.username;
+
+        for (const roomName in rooms) {
+            const data = rooms[roomName];
+            if (data.isMain) continue;
+            if (Memory.colonies[roomName]) continue; // Already a colony
+            if (data.owner) continue;
+            if (data.reservation && data.reservation !== myUsername) continue; // Someone else's remote
+            if (data.alertLevel > 0) continue;
+            if ((data.sourceCount || 0) < 2) continue;
+            if (!data.distance || data.distance > MAX_EXPANSION_DISTANCE) continue;
+
+            candidates.push({ name: roomName, sourceCount: data.sourceCount || 0, distance: data.distance });
+        }
+
+        // Most sources first, then closest
+        candidates.sort((a, b) => b.sourceCount - a.sourceCount || a.distance - b.distance);
+        return candidates[0]?.name;
+    }
+
+    private manageExpansion(target: string): void {
+        const targetRoom = Game.rooms[target];
+
+        // Timeout: abandon an expansion that has made no progress for a long time.
+        const started = this.systemInfo.expansionStartTime || Game.time;
+        const claimed = targetRoom?.controller?.my === true;
+        if (!claimed && Game.time - started > 10000) {
+            Logger.warning(`[Expansion] Abandoning stalled expansion to ${target}`);
+            delete this.systemInfo.expansionTarget;
+            delete this.systemInfo.expansionStartTime;
+            return;
+        }
+
+        if (!targetRoom || !claimed) return; // Waiting on claimer (and vision)
+
+        // Room is claimed. Does it have a spawn yet?
+        const spawns = targetRoom.find(FIND_MY_SPAWNS);
+        if (spawns.length > 0) {
+            Logger.info(`[Expansion] Expansion to ${target} complete — new colony is live.`);
+            // Stop treating the room as a remote of this colony; it's a colony now.
+            delete this.colony.colonyInfo.rooms[target];
+            delete this.systemInfo.expansionTarget;
+            delete this.systemInfo.expansionStartTime;
+            return;
+        }
+
+        // Place the first spawn site if it's missing
+        const spawnSites = targetRoom.find(FIND_MY_CONSTRUCTION_SITES, {
+            filter: s => s.structureType === STRUCTURE_SPAWN,
+        });
+        if (spawnSites.length === 0) {
+            this.placeFirstSpawn(targetRoom);
+        }
+    }
+
+    private placeFirstSpawn(room: Room): void {
+        const pos = ExpansionSystem.findFirstSpawnPosition(room);
+        if (!pos) {
+            Logger.warning(`[Expansion] Could not find a spawn position in ${room.name}`);
+            return;
+        }
+
+        const result = room.createConstructionSite(pos, STRUCTURE_SPAWN);
+        if (result === OK) {
+            Logger.info(`[Expansion] Placed first spawn site in ${room.name} at ${pos.x},${pos.y}`);
+        }
+    }
+
+    /**
+     * Finds an open area for the new colony's first spawn: spirals out from the
+     * controller looking for a tile whose neighbors are all buildable.
+     */
+    public static findFirstSpawnPosition(room: Room): RoomPosition | null {
+        if (!room.controller) return null;
+        const terrain = room.getTerrain();
+        const anchor = room.controller.pos;
+
+        for (let radius = 3; radius <= 10; radius++) {
+            for (let dx = -radius; dx <= radius; dx++) {
+                for (let dy = -radius; dy <= radius; dy++) {
+                    if (Math.max(Math.abs(dx), Math.abs(dy)) !== radius) continue;
+
+                    const x = anchor.x + dx;
+                    const y = anchor.y + dy;
+                    if (x < 4 || x > 45 || y < 4 || y > 45) continue;
+
+                    const pos = new RoomPosition(x, y, room.name);
+                    if (!ConstructionUtils.isTileClearForStructure(pos, room)) continue;
+
+                    // All 8 neighbors must be walkable so the spawn isn't boxed in
+                    let clear = true;
+                    for (let nx = -1; nx <= 1 && clear; nx++) {
+                        for (let ny = -1; ny <= 1 && clear; ny++) {
+                            if (terrain.get(x + nx, y + ny) === TERRAIN_MASK_WALL) {
+                                clear = false;
+                            }
+                        }
+                    }
+                    if (clear) return pos;
+                }
+            }
+        }
+        return null;
+    }
+
+    public override getCreepSpawners(): CreepSpawner[] {
+        return [new ClaimerCreepSpawner(), new PioneerCreepSpawner()];
+    }
+
+    public override getRolesToTrackEnergy(): CreepRole[] {
+        return [CreepRole.PIONEER];
+    }
+
+    public override getStatus(): string | null {
+        const target = this.systemInfo.expansionTarget;
+        if (!target) return null;
+
+        const targetRoom = Game.rooms[target];
+        if (targetRoom?.controller?.my) {
+            return `Founding colony in ${target}`;
+        }
+        return `Claiming ${target}`;
+    }
+}

--- a/src/systems/infrastructure-system.ts
+++ b/src/systems/infrastructure-system.ts
@@ -2,6 +2,7 @@ import { CreepRole } from "prototypes/types";
 import { CreepSpawner } from "prototypes/CreepSpawner";
 
 import { BaseSystemImpl } from "./base-system";
+import { LabHaulerCreepSpawner } from "creep-roles/lab-hauler-creep";
 import { RepairerCreepSpawner } from "creep-roles/repairer-creep";
 import { RepairUtils } from "utils/repair-utils";
 import { Logger } from "utils/logger";
@@ -121,6 +122,6 @@ export class InfrastructureSystem extends BaseSystemImpl {
     }
 
     public override getCreepSpawners(): CreepSpawner[] {
-        return [new RepairerCreepSpawner()];
+        return [new RepairerCreepSpawner(), new LabHaulerCreepSpawner()];
     }
 }

--- a/src/utils/construction-utils.ts
+++ b/src/utils/construction-utils.ts
@@ -270,6 +270,62 @@ export class ConstructionUtils {
         return structures;
     }
 
+    /**
+     * Finds clear tiles for late-game structures (labs, factory, observer) by spiraling
+     * outward from the spawn, keeping placements adjacent to each other where possible.
+     */
+    public static getClusteredStructures(
+        spawn: StructureSpawn,
+        room: Room,
+        type: BuildableStructureConstant,
+        count: number,
+    ): ProjectStructure[] {
+        const structures: ProjectStructure[] = [];
+        if (count <= 0) return structures;
+
+        // Prefer clustering near existing structures of the same type (labs need range 2 of each other).
+        const existing = room.find(FIND_MY_STRUCTURES, { filter: s => s.structureType === type });
+        const existingSites = room.find(FIND_MY_CONSTRUCTION_SITES, { filter: s => s.structureType === type });
+        const anchor = existing[0]?.pos || existingSites[0]?.pos || spawn.pos;
+
+        for (let radius = 2; radius <= 8 && structures.length < count; radius++) {
+            for (let dx = -radius; dx <= radius && structures.length < count; dx++) {
+                for (let dy = -radius; dy <= radius && structures.length < count; dy++) {
+                    // Only check ring perimeter
+                    if (Math.max(Math.abs(dx), Math.abs(dy)) !== radius) continue;
+
+                    const x = anchor.x + dx;
+                    const y = anchor.y + dy;
+                    if (x < 2 || x > 47 || y < 2 || y > 47) continue;
+
+                    const pos = new RoomPosition(x, y, room.name);
+                    if (!ConstructionUtils.isTileClearForStructure(pos, room)) continue;
+
+                    // Don't wall in the spawn: keep at least range 2 from spawn
+                    if (pos.inRangeTo(spawn.pos, 1)) continue;
+
+                    // Avoid tiles already promised to another structure in this batch
+                    if (structures.some(s => s.x === x && s.y === y)) continue;
+
+                    // Labs must be within range 2 of each other to run reactions
+                    if (type === STRUCTURE_LAB) {
+                        const nearOtherLab =
+                            existing.some(s => s.pos.inRangeTo(pos, 2)) ||
+                            existingSites.some(s => s.pos.inRangeTo(pos, 2)) ||
+                            structures.some(s => Math.max(Math.abs(s.x - x), Math.abs(s.y - y)) <= 2);
+                        const isFirstLab =
+                            existing.length === 0 && existingSites.length === 0 && structures.length === 0;
+                        if (!isFirstLab && !nearOtherLab) continue;
+                    }
+
+                    structures.push({ x, y, roomName: room.name, type });
+                }
+            }
+        }
+
+        return structures;
+    }
+
     public static getTowerStructures(spawn: StructureSpawn, numTowers: number): ProjectStructure[] {
         const structures: ProjectStructure[] = [];
         const candidates = [

--- a/src/utils/min-cut.test.ts
+++ b/src/utils/min-cut.test.ts
@@ -1,0 +1,151 @@
+import { expect } from "chai";
+import { MinCut, TerrainLike } from "./min-cut";
+
+const WALL = 1;
+
+/** Terrain where every tile is plains. */
+const openTerrain: TerrainLike = { get: () => 0 };
+
+/** Builds terrain from a set of wall positions. */
+function terrainWithWalls(walls: Set<string>): TerrainLike {
+    return { get: (x: number, y: number) => (walls.has(`${x},${y}`) ? WALL : 0) };
+}
+
+/**
+ * Property check: with the cut tiles blocked, no exit tile may reach the protected rect.
+ */
+function verifySeparation(
+    terrain: TerrainLike,
+    cut: { x: number; y: number }[],
+    rect: { x1: number; y1: number; x2: number; y2: number },
+): boolean {
+    const blocked = new Set(cut.map(c => `${c.x},${c.y}`));
+    const seen = new Set<string>();
+    const queue: { x: number; y: number }[] = [];
+
+    for (let i = 0; i < 50; i++) {
+        for (const [x, y] of [
+            [i, 0],
+            [i, 49],
+            [0, i],
+            [49, i],
+        ]) {
+            if (terrain.get(x, y) === 0 && !blocked.has(`${x},${y}`)) {
+                queue.push({ x, y });
+                seen.add(`${x},${y}`);
+            }
+        }
+    }
+
+    while (queue.length > 0) {
+        const { x, y } = queue.pop() as { x: number; y: number };
+        if (x >= rect.x1 && x <= rect.x2 && y >= rect.y1 && y <= rect.y2) {
+            return false; // Reached the protected area
+        }
+        for (let dx = -1; dx <= 1; dx++) {
+            for (let dy = -1; dy <= 1; dy++) {
+                if (dx === 0 && dy === 0) continue;
+                const nx = x + dx;
+                const ny = y + dy;
+                if (nx < 0 || nx > 49 || ny < 0 || ny > 49) continue;
+                const key = `${nx},${ny}`;
+                if (seen.has(key) || blocked.has(key)) continue;
+                if (terrain.get(nx, ny) !== 0) continue;
+                seen.add(key);
+                queue.push({ x: nx, y: ny });
+            }
+        }
+    }
+    return true;
+}
+
+describe("MinCut", () => {
+    it("should produce a cut that seals the protected area in an open room", () => {
+        const rect = { x1: 20, y1: 20, x2: 30, y2: 30 };
+        const cut = MinCut.computeCut(openTerrain, [rect], WALL);
+
+        expect(cut.length).to.be.greaterThan(0);
+        expect(verifySeparation(openTerrain, cut, rect)).to.equal(true);
+    });
+
+    it("should keep the cut away from exit tiles", () => {
+        const rect = { x1: 20, y1: 20, x2: 30, y2: 30 };
+        const cut = MinCut.computeCut(openTerrain, [rect], WALL);
+
+        for (const tile of cut) {
+            expect(tile.x).to.be.greaterThan(1);
+            expect(tile.x).to.be.lessThan(48);
+            expect(tile.y).to.be.greaterThan(1);
+            expect(tile.y).to.be.lessThan(48);
+        }
+    });
+
+    it("should exploit terrain walls to shrink the cut", () => {
+        // Wall off everything except a corridor at y=24..26, x<20
+        const walls = new Set<string>();
+        for (let x = 0; x < 50; x++) {
+            for (let y = 0; y < 50; y++) {
+                const inCorridor = y >= 24 && y <= 26 && x < 20;
+                const inBase = x >= 20 && x <= 34 && y >= 15 && y <= 35;
+                if (!inCorridor && !inBase && x !== 0 && x !== 49 && y !== 0 && y !== 49) {
+                    walls.add(`${x},${y}`);
+                }
+            }
+        }
+        // Keep left border open as the only exit; wall the other borders
+        for (let i = 0; i < 50; i++) {
+            walls.add(`${i},0`);
+            walls.add(`${i},49`);
+            walls.add(`49,${i}`);
+        }
+        for (let y = 0; y < 50; y++) {
+            if (y < 24 || y > 26) walls.add(`0,${y}`);
+        }
+
+        const terrain = terrainWithWalls(walls);
+        const rect = { x1: 25, y1: 20, x2: 30, y2: 30 };
+        const cut = MinCut.computeCut(terrain, [rect], WALL);
+
+        // The corridor is 3 wide, so the cut should be exactly 3 tiles
+        expect(cut.length).to.equal(3);
+        expect(verifySeparation(terrain, cut, rect)).to.equal(true);
+    });
+
+    it("should return empty when the protected area touches the exit border", () => {
+        const rect = { x1: 0, y1: 20, x2: 10, y2: 30 };
+        const cut = MinCut.computeCut(openTerrain, [rect], WALL);
+        expect(cut).to.deep.equal([]);
+    });
+
+    it("should return empty when terrain already seals the area", () => {
+        // Full wall ring at x/y = 10..40 borders
+        const walls = new Set<string>();
+        for (let i = 10; i <= 40; i++) {
+            walls.add(`${i},10`);
+            walls.add(`${i},40`);
+            walls.add(`10,${i}`);
+            walls.add(`40,${i}`);
+        }
+        const terrain = terrainWithWalls(walls);
+        const rect = { x1: 20, y1: 20, x2: 30, y2: 30 };
+        const cut = MinCut.computeCut(terrain, [rect], WALL);
+        expect(cut).to.deep.equal([]);
+    });
+
+    describe("getProtectedRects", () => {
+        it("should build a padded bounding box clamped away from the border", () => {
+            const rects = MinCut.getProtectedRects(
+                [
+                    { x: 5, y: 25 },
+                    { x: 30, y: 30 },
+                ],
+                4,
+            );
+            expect(rects).to.deep.equal([{ x1: 3, y1: 21, x2: 34, y2: 34 }]);
+        });
+
+        it("should return empty for no positions", () => {
+            expect(MinCut.getProtectedRects([], 3)).to.deep.equal([]);
+        });
+    });
+});

--- a/src/utils/min-cut.ts
+++ b/src/utils/min-cut.ts
@@ -1,0 +1,234 @@
+/* eslint-disable no-bitwise */
+/**
+ * Minimum-cut based perimeter planner.
+ *
+ * Models the room as a flow network (exits = source side, protected area = sink side,
+ * each buildable tile has capacity 1) and computes the max-flow / min-cut. The cut is
+ * the smallest set of tiles that, when walled with ramparts, separates every exit from
+ * the protected area.
+ */
+
+export interface TerrainLike {
+    get(x: number, y: number): number;
+}
+
+export interface Rect {
+    x1: number;
+    y1: number;
+    x2: number;
+    y2: number;
+}
+
+interface Edge {
+    to: number;
+    cap: number;
+    /** Index of the reverse edge in graph[to]. */
+    rev: number;
+}
+
+const ROOM_SIZE = 50;
+const INF = 1 << 20;
+/** Safety valve: a max-flow this large means the protected area leaks into an exit. */
+const MAX_REASONABLE_FLOW = 500;
+
+export class MinCut {
+    /**
+     * Computes the tiles to rampart so that the protected rectangles are sealed off
+     * from all room exits. Returns an empty array when no finite cut exists (e.g. a
+     * protected rect touches the exit border).
+     */
+    public static computeCut(
+        terrain: TerrainLike,
+        protectedRects: Rect[],
+        terrainWallMask: number,
+    ): { x: number; y: number }[] {
+        const isWall = (x: number, y: number): boolean => (terrain.get(x, y) & terrainWallMask) !== 0;
+
+        const inNode = (x: number, y: number) => (y * ROOM_SIZE + x) * 2;
+        const outNode = (x: number, y: number) => (y * ROOM_SIZE + x) * 2 + 1;
+        const SOURCE = ROOM_SIZE * ROOM_SIZE * 2;
+        const SINK = SOURCE + 1;
+        const nodeCount = SINK + 1;
+
+        const graph: Edge[][] = new Array(nodeCount);
+        for (let i = 0; i < nodeCount; i++) graph[i] = [];
+
+        const addEdge = (from: number, to: number, cap: number) => {
+            graph[from].push({ to, cap, rev: graph[to].length });
+            graph[to].push({ to: from, cap: 0, rev: graph[from].length - 1 });
+        };
+
+        const inRect = (x: number, y: number): boolean =>
+            protectedRects.some(r => x >= r.x1 && x <= r.x2 && y >= r.y1 && y <= r.y2);
+
+        const isExit = (x: number, y: number): boolean =>
+            (x === 0 || x === ROOM_SIZE - 1 || y === 0 || y === ROOM_SIZE - 1) && !isWall(x, y);
+
+        const nearExit = (x: number, y: number): boolean => {
+            for (let dx = -1; dx <= 1; dx++) {
+                for (let dy = -1; dy <= 1; dy++) {
+                    const nx = x + dx;
+                    const ny = y + dy;
+                    if (nx < 0 || nx >= ROOM_SIZE || ny < 0 || ny >= ROOM_SIZE) continue;
+                    if (isExit(nx, ny)) return true;
+                }
+            }
+            return false;
+        };
+
+        // If any protected tile is an exit or exit-adjacent, no finite cut exists.
+        for (const r of protectedRects) {
+            for (let x = r.x1; x <= r.x2; x++) {
+                for (let y = r.y1; y <= r.y2; y++) {
+                    if (!isWall(x, y) && (isExit(x, y) || nearExit(x, y))) {
+                        return [];
+                    }
+                }
+            }
+        }
+
+        // Build the graph
+        for (let x = 0; x < ROOM_SIZE; x++) {
+            for (let y = 0; y < ROOM_SIZE; y++) {
+                if (isWall(x, y)) continue;
+
+                // Tile capacity: 1 if a rampart here can block, INF if unbuildable/protected.
+                let cap = 1;
+                if (inRect(x, y)) cap = INF;
+                else if (isExit(x, y) || nearExit(x, y)) cap = INF;
+
+                addEdge(inNode(x, y), outNode(x, y), cap);
+
+                // Source feeds exits, protected area drains to sink.
+                if (isExit(x, y)) addEdge(SOURCE, inNode(x, y), INF);
+                if (inRect(x, y)) addEdge(outNode(x, y), SINK, INF);
+
+                // 8-directional movement edges
+                for (let dx = -1; dx <= 1; dx++) {
+                    for (let dy = -1; dy <= 1; dy++) {
+                        if (dx === 0 && dy === 0) continue;
+                        const nx = x + dx;
+                        const ny = y + dy;
+                        if (nx < 0 || nx >= ROOM_SIZE || ny < 0 || ny >= ROOM_SIZE) continue;
+                        if (isWall(nx, ny)) continue;
+                        addEdge(outNode(x, y), inNode(nx, ny), INF);
+                    }
+                }
+            }
+        }
+
+        // Edmonds-Karp max flow
+        let totalFlow = 0;
+        for (;;) {
+            const { parentEdge, parentNode } = MinCut.bfs(graph, SOURCE, SINK);
+            if (parentNode[SINK] === -1) break;
+
+            // Find bottleneck
+            let bottleneck = INF;
+            for (let v = SINK; v !== SOURCE; v = parentNode[v]) {
+                const edge = graph[parentNode[v]][parentEdge[v]];
+                bottleneck = Math.min(bottleneck, edge.cap);
+            }
+
+            // Augment
+            for (let v = SINK; v !== SOURCE; v = parentNode[v]) {
+                const edge = graph[parentNode[v]][parentEdge[v]];
+                edge.cap -= bottleneck;
+                graph[edge.to][edge.rev].cap += bottleneck;
+            }
+
+            totalFlow += bottleneck;
+            if (totalFlow > MAX_REASONABLE_FLOW) {
+                return []; // Room can't be sealed with a sensible number of ramparts
+            }
+        }
+
+        if (totalFlow === 0) {
+            return []; // Exits can't reach the protected area at all (or nothing to protect)
+        }
+
+        // Min cut: tiles whose in-node is reachable from SOURCE in the residual graph
+        // but whose out-node is not.
+        const reachable = MinCut.residualReachable(graph, SOURCE);
+        const cut: { x: number; y: number }[] = [];
+        for (let x = 0; x < ROOM_SIZE; x++) {
+            for (let y = 0; y < ROOM_SIZE; y++) {
+                if (isWall(x, y)) continue;
+                if (reachable[inNode(x, y)] && !reachable[outNode(x, y)]) {
+                    cut.push({ x, y });
+                }
+            }
+        }
+        return cut;
+    }
+
+    private static bfs(graph: Edge[][], source: number, sink: number): { parentEdge: number[]; parentNode: number[] } {
+        const parentNode = new Array(graph.length).fill(-1);
+        const parentEdge = new Array(graph.length).fill(-1);
+        parentNode[source] = source;
+
+        const queue: number[] = [source];
+        let head = 0;
+        while (head < queue.length) {
+            const u = queue[head++];
+            if (u === sink) break;
+            const edges = graph[u];
+            for (let i = 0; i < edges.length; i++) {
+                const edge = edges[i];
+                if (edge.cap > 0 && parentNode[edge.to] === -1) {
+                    parentNode[edge.to] = u;
+                    parentEdge[edge.to] = i;
+                    queue.push(edge.to);
+                }
+            }
+        }
+
+        return { parentEdge, parentNode };
+    }
+
+    private static residualReachable(graph: Edge[][], source: number): boolean[] {
+        const seen = new Array(graph.length).fill(false);
+        seen[source] = true;
+        const queue: number[] = [source];
+        let head = 0;
+        while (head < queue.length) {
+            const u = queue[head++];
+            for (const edge of graph[u]) {
+                if (edge.cap > 0 && !seen[edge.to]) {
+                    seen[edge.to] = true;
+                    queue.push(edge.to);
+                }
+            }
+        }
+        return seen;
+    }
+
+    /**
+     * Builds padded bounding rectangles around the positions worth protecting,
+     * clamped away from the room border.
+     */
+    public static getProtectedRects(positions: { x: number; y: number }[], padding: number): Rect[] {
+        if (positions.length === 0) return [];
+
+        let minX = ROOM_SIZE;
+        let minY = ROOM_SIZE;
+        let maxX = 0;
+        let maxY = 0;
+        for (const pos of positions) {
+            minX = Math.min(minX, pos.x);
+            minY = Math.min(minY, pos.y);
+            maxX = Math.max(maxX, pos.x);
+            maxY = Math.max(maxY, pos.y);
+        }
+
+        const clamp = (v: number) => Math.max(3, Math.min(ROOM_SIZE - 4, v));
+        return [
+            {
+                x1: clamp(minX - padding),
+                y1: clamp(minY - padding),
+                x2: clamp(maxX + padding),
+                y2: clamp(maxY + padding),
+            },
+        ];
+    }
+}

--- a/src/utils/room-utils.ts
+++ b/src/utils/room-utils.ts
@@ -33,7 +33,9 @@ export class RoomUtils {
         let alertLevel = 0;
         if (threat.totalHostiles > 0) {
             if (threat.attackPower > 0 || threat.healPower > 0) {
-                alertLevel = 2;
+                // Scale alert with the size of the incursion so the defender
+                // response (which is derived from alertLevel) scales too.
+                alertLevel = 2 + Math.min(3, Math.floor((threat.attackPower + threat.healPower) / 200));
             } else {
                 alertLevel = 1;
             }
@@ -41,7 +43,7 @@ export class RoomUtils {
         // Also check for hostile structures (invader cores, etc.)
         const hostileStructures = room.find(FIND_HOSTILE_STRUCTURES);
         if (hostileStructures.length > 0) {
-            alertLevel = 2;
+            alertLevel = Math.max(alertLevel, 2);
         }
 
         roomData.alertLevel = alertLevel;

--- a/src/utils/threat-assessment.test.ts
+++ b/src/utils/threat-assessment.test.ts
@@ -1,0 +1,97 @@
+import { expect } from "chai";
+import { ThreatAssessment } from "./threat-assessment";
+
+describe("ThreatAssessment", () => {
+    beforeEach(() => {
+        (global as any).TOWER_POWER_ATTACK = 600;
+        (global as any).TOWER_OPTIMAL_RANGE = 5;
+        (global as any).TOWER_FALLOFF_RANGE = 20;
+        (global as any).TOWER_FALLOFF = 0.75;
+        (global as any).TOWER_ENERGY_COST = 10;
+        (global as any).ATTACK_POWER = 30;
+        (global as any).RANGED_ATTACK_POWER = 10;
+        (global as any).HEAL_POWER = 12;
+        (global as any).ATTACK = "attack";
+        (global as any).RANGED_ATTACK = "ranged_attack";
+        (global as any).HEAL = "heal";
+        (global as any).RESOURCE_ENERGY = "energy";
+    });
+
+    describe("towerDamageAtRange", () => {
+        it("should deal full damage at or below optimal range", () => {
+            expect(ThreatAssessment.towerDamageAtRange(1)).to.equal(600);
+            expect(ThreatAssessment.towerDamageAtRange(5)).to.equal(600);
+        });
+
+        it("should deal minimum damage at or beyond falloff range", () => {
+            expect(ThreatAssessment.towerDamageAtRange(20)).to.equal(150);
+            expect(ThreatAssessment.towerDamageAtRange(49)).to.equal(150);
+        });
+
+        it("should interpolate linearly between optimal and falloff range", () => {
+            // Halfway (range 12.5 -> use 12): 600 - 600*0.75*(7/15) = 600 - 210 = 390
+            expect(ThreatAssessment.towerDamageAtRange(12)).to.equal(600 - Math.ceil(600 * 0.75 * (7 / 15)));
+        });
+    });
+
+    describe("selectTowerTarget", () => {
+        const makeTower = (energy: number, range: number): any => ({
+            store: { energy },
+            pos: { getRangeTo: () => range },
+        });
+
+        const makeHostile = (opts: { heal?: number; hits?: number; near?: boolean }): any => ({
+            id: `${Math.random()}`,
+            hits: opts.hits ?? 1000,
+            hitsMax: 1000,
+            getActiveBodyparts: (part: string) => (part === "heal" ? opts.heal || 0 : 0),
+            pos: { inRangeTo: () => opts.near ?? true },
+        });
+
+        it("should return null when no towers have energy", () => {
+            const report = {
+                hostiles: [makeHostile({})],
+            } as any;
+            expect(ThreatAssessment.selectTowerTarget([makeTower(0, 5)], report)).to.equal(null);
+        });
+
+        it("should return null when hostiles out-heal tower damage", () => {
+            // Tower at max falloff range does 150; healer heals 50*12=600 > 150
+            const healer = makeHostile({ heal: 50 });
+            const report = { hostiles: [healer] } as any;
+            expect(ThreatAssessment.selectTowerTarget([makeTower(1000, 25)], report)).to.equal(null);
+        });
+
+        it("should prefer healers over other hostiles", () => {
+            const healer = makeHostile({ heal: 2 });
+            const brawler = makeHostile({ hits: 100 });
+            const report = { hostiles: [brawler, healer] } as any;
+            const target = ThreatAssessment.selectTowerTarget([makeTower(1000, 5)], report);
+            expect(target).to.equal(healer);
+        });
+
+        it("should pick a killable target at close range", () => {
+            const hostile = makeHostile({});
+            const report = { hostiles: [hostile] } as any;
+            const target = ThreatAssessment.selectTowerTarget([makeTower(1000, 5)], report);
+            expect(target).to.equal(hostile);
+        });
+    });
+
+    describe("effectiveHealFor", () => {
+        it("should sum the target's own heal and nearby hostiles' heal", () => {
+            const target: any = {
+                id: "t",
+                getActiveBodyparts: (p: string) => (p === "heal" ? 2 : 0),
+                pos: {},
+            };
+            const nearHealer: any = {
+                id: "h1",
+                getActiveBodyparts: (p: string) => (p === "heal" ? 3 : 0),
+                pos: { inRangeTo: () => true },
+            };
+            // Target heals itself (2*12) + friend (3*12) = 60
+            expect(ThreatAssessment.effectiveHealFor(target, [target, nearHealer])).to.equal(60);
+        });
+    });
+});

--- a/src/utils/threat-assessment.ts
+++ b/src/utils/threat-assessment.ts
@@ -1,5 +1,6 @@
 export interface ThreatReport {
     totalHostiles: number;
+    hostiles: Creep[];
     attackPower: number;
     healPower: number;
     maxIndividualHits: number;
@@ -35,6 +36,7 @@ export class ThreatAssessment {
 
         return {
             totalHostiles: hostiles.length,
+            hostiles,
             attackPower,
             healPower,
             maxIndividualHits,
@@ -43,14 +45,83 @@ export class ThreatAssessment {
         };
     }
 
-    private static calculateAttackPower(creep: Creep): number {
+    public static calculateAttackPower(creep: Creep): number {
         return (
             creep.getActiveBodyparts(ATTACK) * ATTACK_POWER +
             creep.getActiveBodyparts(RANGED_ATTACK) * RANGED_ATTACK_POWER
         );
     }
 
-    private static calculateHealPower(creep: Creep): number {
+    public static calculateHealPower(creep: Creep): number {
         return creep.getActiveBodyparts(HEAL) * HEAL_POWER;
+    }
+
+    /** Damage a single tower deals to a target at the given range, accounting for falloff. */
+    public static towerDamageAtRange(range: number): number {
+        if (range <= TOWER_OPTIMAL_RANGE) {
+            return TOWER_POWER_ATTACK;
+        }
+        const falloffRange = Math.min(range, TOWER_FALLOFF_RANGE);
+        const falloffFraction = (falloffRange - TOWER_OPTIMAL_RANGE) / (TOWER_FALLOFF_RANGE - TOWER_OPTIMAL_RANGE);
+        return Math.floor(TOWER_POWER_ATTACK * (1 - TOWER_FALLOFF * falloffFraction));
+    }
+
+    /** Total damage per tick the given towers can deal to a position. Only counts towers with enough energy to fire. */
+    public static totalTowerDamage(towers: StructureTower[], pos: RoomPosition): number {
+        let damage = 0;
+        for (const tower of towers) {
+            if (tower.store[RESOURCE_ENERGY] < TOWER_ENERGY_COST) continue;
+            damage += this.towerDamageAtRange(tower.pos.getRangeTo(pos));
+        }
+        return damage;
+    }
+
+    /** Heal per tick that can plausibly reach the target: its own heal plus heal from hostiles within range 3. */
+    public static effectiveHealFor(target: Creep, hostiles: Creep[]): number {
+        let heal = 0;
+        for (const hostile of hostiles) {
+            if (hostile.id === target.id || hostile.pos.inRangeTo(target, 3)) {
+                heal += this.calculateHealPower(hostile);
+            }
+        }
+        return heal;
+    }
+
+    /**
+     * Picks the best focus-fire target for the room's towers.
+     * Prefers targets the towers can actually out-damage (net damage > 0),
+     * prioritizing healers, then lowest hits. Returns null when every hostile
+     * out-heals our damage — firing would only drain energy.
+     */
+    public static selectTowerTarget(towers: StructureTower[], report: ThreatReport): Creep | null {
+        const activeTowers = towers.filter(t => t.store[RESOURCE_ENERGY] >= TOWER_ENERGY_COST);
+        if (activeTowers.length === 0 || report.hostiles.length === 0) {
+            return null;
+        }
+
+        let best: Creep | null = null;
+        let bestScore = -Infinity;
+
+        for (const hostile of report.hostiles) {
+            const damage = this.totalTowerDamage(activeTowers, hostile.pos);
+            const heal = this.effectiveHealFor(hostile, report.hostiles);
+            const netDamage = damage - heal;
+            if (netDamage <= 0) continue;
+
+            // Score: net damage, with a strong bonus for healers (removing heal support
+            // makes everything else killable) and a bonus for nearly-dead targets.
+            let score = netDamage;
+            if (hostile.getActiveBodyparts(HEAL) > 0) {
+                score += 1000;
+            }
+            score += (1 - hostile.hits / hostile.hitsMax) * 500;
+
+            if (score > bestScore) {
+                bestScore = score;
+                best = hostile;
+            }
+        }
+
+        return best;
     }
 }


### PR DESCRIPTION
## What changed

This PR makes the AI substantially more competitive across three areas: defending/securing rooms, actually using higher-RCL unlocks, and founding new colonies automatically.

### Defense & room security
- **Tower focus-fire with damage math** (`threat-assessment.ts`): all towers concentrate on one target chosen by computing real tower damage (range falloff) minus the heal power that can reach the target. Healers are prioritized, and towers hold fire against heal-tanks they cannot out-damage instead of draining energy.
- **Min-cut rampart perimeter** (`min-cut.ts`): Edmonds-Karp max-flow over the room grid computes the provably minimal set of rampart positions sealing the base from every exit, exploiting terrain walls. Computed once per RCL (cached in memory), built 5 sites at a time from RCL 4.
- **Ramparts over critical structures** from RCL 3 (spawns, towers, storage, terminal, labs, factory).
- **Threat-scaled alerts**: alert level scales with hostile attack+heal power, so defender counts scale with invasion size.
- **New ranged defender role** that kites melee attackers (fights at range 3, retreats from ATTACK creeps within 2, mass-attacks when swarmed).
- Melee defenders and towers kill enemy healers first; smarter safe-mode triggers (spawn below 50% HP, or no defenders *and* no powered towers).

### Higher-RCL unlocks (built before, never used)
- **LinkManager**: source links feed the controller link, then the core link; upgraders/builders withdraw from receiving links.
- **LabManager + lab hauler role**: picks the highest-priority combat compound producible from on-hand minerals, runs reactions, banks products. Defenders boost themselves (best tier available) before engaging.
- **Mineral mining**: new mineral miner role works the extractor and hauls to terminal/storage from RCL 6.
- **TerminalManager**: auto-sells surplus *raw* minerals on the market (compounds are kept for boosting); extension fillers stock the terminal with fee energy.
- **Structure planning** for labs (RCL 6, placed within reaction range), factory (RCL 7), observer (RCL 8).

### Colony expansion
- **ExpansionSystem**: when GCL allows and the colony is RCL 4+ with a healthy energy buffer, picks the best scouted room (2+ sources, safe, unowned), sends a claimer, places the first spawn site near the controller, and bootstraps with pioneer creeps. Stalled expansions time out after 10k ticks.
- **Inter-colony energy sharing**: colonies above 70% stored energy ship 10k energy to sister colonies below 30% via terminal.
- **Bug fix**: building a second spawn in a room that already had a colony no longer wipes that colony''s memory (it attaches and adopts orphaned spawns instead).

## Why

The AI had a solid economy engine but no answer to organized attacks (towers were trivially heal-tanked, no fortifications were ever built), left links/terminal/extractor idle after building them, and had no path to multi-room play.

## Notes for review

- Test suite grew from 110 to 134 passing; the min-cut planner has a property test that floods from the exits and asserts the base is unreachable.
- The min-cut computation is a one-time cost per RCL (paid from the CPU bucket), cached in `defenseManagement.perimeter`.
- `npm run build` and `npx eslint` are clean on all touched files (repo-wide lint has pre-existing errors; the `lint` script is `eslint || true`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)